### PR TITLE
bugfix/update connected wallets state after disconection

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,3 +1,7 @@
 {
-  "recommendations": ["bradlc.vscode-tailwindcss", "esbenp.prettier-vscode"]
+  "recommendations": [
+    "bradlc.vscode-tailwindcss",
+    "esbenp.prettier-vscode",
+    "dbaeumer.vscode-eslint"
+  ]
 }

--- a/apps/dex/src/pages/_app.tsx
+++ b/apps/dex/src/pages/_app.tsx
@@ -19,9 +19,9 @@ function MyApp({ Component, pageProps }: AppProps) {
       }),
   );
   return (
-    <CosmConnectProvider>
-      <WagmiProvider>
-        <QueryClientProvider client={queryClient}>
+    <QueryClientProvider client={queryClient}>
+      <CosmConnectProvider>
+        <WagmiProvider>
           <Hydrate state={pageProps.dehydratedState}>
             <CookiesProvider>
               <MainLayout>
@@ -30,9 +30,9 @@ function MyApp({ Component, pageProps }: AppProps) {
             </CookiesProvider>
           </Hydrate>
           <ReactQueryDevtools position="bottom-right" />
-        </QueryClientProvider>
-      </WagmiProvider>
-    </CosmConnectProvider>
+        </WagmiProvider>
+      </CosmConnectProvider>
+    </QueryClientProvider>
   );
 }
 

--- a/packages/ui/src/compounds/WalletSelector/types.ts
+++ b/packages/ui/src/compounds/WalletSelector/types.ts
@@ -2,6 +2,7 @@ import type { ReactNode } from "react";
 
 export type ChainEntry = {
   id: string;
+  chainId: string;
   name: string;
   type: string;
   icon: ReactNode;


### PR DESCRIPTION
- replace .id by .chainId for accounts lookup
- replace .id by .chainId for selected chain
- use cosmosActiveConnector for disconnection flow
- omit matching chainIds from current accounts to update the dropdown