### PR TITLE
fix: remove escape of commit lint file param due to macOS support

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,4 +1,4 @@
 #!/usr/bin/env sh
 . "$(dirname -- "$0")/_/husky.sh"
 
-npx --no -- commitlint --edit "\${1}"
+npx --no -- commitlint --edit $1


### PR DESCRIPTION
More information in:
https://github.com/conventional-changelog/commitlint/issues/589
