### PR TITLE
feat: balances total, available & pooled in usdc

### DIFF
--- a/apps/dex/src/pages/balances.tsx
+++ b/apps/dex/src/pages/balances.tsx
@@ -16,7 +16,10 @@ import { FC, useCallback, useMemo, useState } from "react";
 import AssetIcon from "~/compounds/AssetIcon";
 import ExportModal from "~/compounds/ExportModal";
 import ImportModal from "~/compounds/ImportModal";
-import { useBalancesWithPool } from "~/domains/bank/hooks/balances";
+import {
+  useBalancesStats,
+  useBalancesWithPool,
+} from "~/domains/bank/hooks/balances";
 
 const Stat: FC<{ label: string; value: string }> = (props) => (
   <div className="flex-1 grid gap-1">
@@ -46,6 +49,7 @@ const TokenFigure = (props: {
 const AssetsPage: NextPage = () => {
   const router = useRouter();
   const balances = useBalancesWithPool();
+  const balancesStats = useBalancesStats();
 
   const [selectedDenom, setSelectedDenom] = useState<string | undefined>();
   const selectedBalance = useMemo(
@@ -90,18 +94,22 @@ const AssetsPage: NextPage = () => {
     return [
       {
         label: "Total",
-        value: 10,
+        value: balancesStats.data?.totalInUsdc.toFloatApproximation() ?? 0,
       },
       {
         label: "Available",
-        value: 100000,
+        value: balancesStats.data?.availableInUsdc.toFloatApproximation() ?? 0,
       },
       {
         label: "Pooled",
-        value: 100000,
+        value: balancesStats.data?.pooledInUsdc.toFloatApproximation() ?? 0,
       },
     ];
-  }, []);
+  }, [
+    balancesStats.data?.availableInUsdc,
+    balancesStats.data?.pooledInUsdc,
+    balancesStats.data?.totalInUsdc,
+  ]);
 
   const actions = useMemo(
     () => [

--- a/apps/dex/src/pages/balances.tsx
+++ b/apps/dex/src/pages/balances.tsx
@@ -94,15 +94,33 @@ const AssetsPage: NextPage = () => {
     return [
       {
         label: "Total",
-        value: balancesStats.data?.totalInUsdc.toFloatApproximation() ?? 0,
+        value:
+          balancesStats.data?.totalInUsdc
+            .toFloatApproximation()
+            .toLocaleString(undefined, {
+              style: "currency",
+              currency: "USD",
+            }) ?? "...",
       },
       {
         label: "Available",
-        value: balancesStats.data?.availableInUsdc.toFloatApproximation() ?? 0,
+        value:
+          balancesStats.data?.availableInUsdc
+            .toFloatApproximation()
+            .toLocaleString(undefined, {
+              style: "currency",
+              currency: "USD",
+            }) ?? "...",
       },
       {
         label: "Pooled",
-        value: balancesStats.data?.pooledInUsdc.toFloatApproximation() ?? 0,
+        value:
+          balancesStats.data?.pooledInUsdc
+            .toFloatApproximation()
+            .toLocaleString(undefined, {
+              style: "currency",
+              currency: "USD",
+            }) ?? "...",
       },
     ];
   }, [
@@ -153,14 +171,7 @@ const AssetsPage: NextPage = () => {
           </div>
           <div className="flex flex-wrap gap-4">
             {stats.map((stat) => (
-              <Stat
-                key={stat.label}
-                label={stat.label}
-                value={stat.value.toLocaleString(undefined, {
-                  style: "currency",
-                  currency: "USD",
-                })}
-              />
+              <Stat key={stat.label} label={stat.label} value={stat.value} />
             ))}
           </div>
         </header>


### PR DESCRIPTION
- Used actual swappable USDC amount on the dex (without fees & slippage)
- Requires querying sifnode 6 times per token, shouldn't be an issue since this is just a read operation, but we have had performance issue due to poorly optimised sifnode before
- Might be a good idea for data service to provide this if performance hit is noticable