### PR TITLE
feat: Add Margin > Portifolio > Open positons and History components

### DIFF
--- a/apps/dex/src/components/Slug.tsx
+++ b/apps/dex/src/components/Slug.tsx
@@ -1,0 +1,14 @@
+import clsx from "clsx";
+
+type SlugProps = {
+  color: string;
+  title: string;
+};
+
+export function Slug({ color, title }: SlugProps) {
+  const clsn = clsx({
+    "text-green-400": color === "green",
+    "text-red-400": color === "red",
+  });
+  return <span className={clsn}>{title}</span>;
+}

--- a/apps/dex/src/compounds/Margin/History.tsx
+++ b/apps/dex/src/compounds/Margin/History.tsx
@@ -1,0 +1,68 @@
+import type { NextPage } from "next";
+
+import { Slug } from "~/components/Slug";
+
+const HISTORY_HEADER_ITEMS = [
+  "Date",
+  "Pool",
+  "Side",
+  "Amount",
+  "Leverage",
+  "Realized P&L",
+];
+
+const Trade: NextPage = () => {
+  return (
+    <div className="overflow-x">
+      <table className="table-auto overflow-scroll w-full text-left text-sm">
+        <thead>
+          <tr className="text-gray-400">
+            {HISTORY_HEADER_ITEMS.map((title) => {
+              return (
+                <th key={title} className="font-normal px-4 py-3">
+                  {title}
+                </th>
+              );
+            })}
+          </tr>
+        </thead>
+        <tbody className="bg-gray-850">
+          <tr>
+            <td className="px-4 py-3">07-05 11:23:51 AM</td>
+            <td className="px-4 py-3">ETH / ROWAN</td>
+            <td className="px-4 py-3">
+              <Slug color="green" title="Long" />
+            </td>
+            <td className="px-4 py-3">5.00000000</td>
+            <td>2x</td>
+            <td className="px-4 py-3">
+              <Slug color="green" title="0.002 (0.0%)" />
+            </td>
+          </tr>
+          <tr>
+            <td className="px-4 py-3">07-05 11:23:51 AM</td>
+            <td className="px-4 py-3">ETH / ROWAN</td>
+            <td className="px-4 py-3">
+              <Slug color="red" title="Short" />
+            </td>
+            <td className="px-4 py-3">5.00000000</td>
+            <td>2x</td>
+            <td className="px-4 py-3">
+              <Slug color="green" title="0.002 (0.0%)" />
+            </td>
+          </tr>
+          <tr>
+            <td
+              colSpan={HISTORY_HEADER_ITEMS.length}
+              className="text-gray-400 text-center p-20"
+            >
+              You have no open positions.
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  );
+};
+
+export default Trade;

--- a/apps/dex/src/compounds/Margin/OpenPositions.tsx
+++ b/apps/dex/src/compounds/Margin/OpenPositions.tsx
@@ -1,0 +1,80 @@
+import type { NextPage } from "next";
+
+import { Slug } from "~/components/Slug";
+
+const OPEN_POSITIONS_HEADER_ITEMS = [
+  "Pool",
+  "Side",
+  "Amount",
+  "Leverage",
+  "BP used",
+  "Unrealized P&L",
+  "Funding rate %",
+  "Unsettled Interest",
+  "Position health",
+  "Close all",
+];
+
+const Trade: NextPage = () => {
+  return (
+    <div className="overflow-x">
+      <table className="table-auto overflow-scroll w-full text-left text-sm">
+        <thead>
+          <tr className="text-gray-400">
+            {OPEN_POSITIONS_HEADER_ITEMS.map((title) => {
+              return (
+                <th key={title} className="font-normal px-4 py-3">
+                  {title}
+                </th>
+              );
+            })}
+          </tr>
+        </thead>
+        <tbody className="bg-gray-850">
+          <tr>
+            <td className="px-4 py-3">ETH / ROWAN</td>
+            <td className="px-4 py-3">
+              <Slug color="green" title="Long" />
+            </td>
+            <td className="px-4 py-3">5.00000000</td>
+            <td className="px-4 py-3">2x</td>
+            <td className="px-4 py-3">&ndash;</td>
+            <td className="px-4 py-3">
+              <Slug color="green" title="0.002 (0.0%)" />
+            </td>
+            <td className="px-4 py-3">&ndash;</td>
+            <td className="px-4 py-3">&ndash;</td>
+            <td className="px-4 py-3">&ndash;</td>
+            <td className="px-4 py-3">Close</td>
+          </tr>
+          <tr>
+            <td className="px-4 py-3">ETH / ROWAN</td>
+            <td className="px-4 py-3">
+              <Slug color="red" title="Short" />
+            </td>
+            <td className="px-4 py-3">5.00000000</td>
+            <td className="px-4 py-3">2x</td>
+            <td className="px-4 py-3">&ndash;</td>
+            <td className="px-4 py-3">
+              <Slug color="green" title="0.002 (0.0%)" />
+            </td>
+            <td className="px-4 py-3">&ndash;</td>
+            <td className="px-4 py-3">&ndash;</td>
+            <td className="px-4 py-3">&ndash;</td>
+            <td className="px-4 py-3">Close</td>
+          </tr>
+          <tr>
+            <td
+              colSpan={OPEN_POSITIONS_HEADER_ITEMS.length}
+              className="text-gray-400 text-center p-20"
+            >
+              You have no open positions.
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  );
+};
+
+export default Trade;

--- a/apps/dex/src/compounds/Margin/Portifolio.tsx
+++ b/apps/dex/src/compounds/Margin/Portifolio.tsx
@@ -26,6 +26,7 @@ const Portifolio: NextPage = () => {
     (router.query["option"] as string) || DEFAULT_OPTION_ITEM;
   const currentTab = OPTIONS_ITEMS.find((item) => item.slug === activeOption);
   const TabContent = currentTab?.content || null;
+
   return (
     <section className="mt-4 rounded bg-gray-800">
       <ul className="flex flex-row">
@@ -48,7 +49,11 @@ const Portifolio: NextPage = () => {
         })}
       </ul>
       {TabContent && (
-        <Suspense fallback="Loading...">
+        <Suspense
+          fallback={
+            <div className="bg-gray-850 p-10 text-center">Loading...</div>
+          }
+        >
           <TabContent />
         </Suspense>
       )}

--- a/apps/dex/src/compounds/Margin/Portifolio.tsx
+++ b/apps/dex/src/compounds/Margin/Portifolio.tsx
@@ -1,7 +1,59 @@
 import type { NextPage } from "next";
 
+import { Suspense } from "react";
+import { useRouter } from "next/router";
+import clsx from "clsx";
+import dynamic from "next/dynamic";
+import Link from "next/link";
+
+const DEFAULT_OPTION_ITEM = "open-positions";
+const OPTIONS_ITEMS = [
+  {
+    title: "Open Positions",
+    slug: "open-positions",
+    content: dynamic(() => import("~/compounds/Margin/OpenPositions")),
+  },
+  {
+    title: "History",
+    slug: "history",
+    content: dynamic(() => import("~/compounds/Margin/History")),
+  },
+];
+
 const Portifolio: NextPage = () => {
-  return <h1>Portifolio Page</h1>;
+  const router = useRouter();
+  const activeOption =
+    (router.query["option"] as string) || DEFAULT_OPTION_ITEM;
+  const currentTab = OPTIONS_ITEMS.find((item) => item.slug === activeOption);
+  const TabContent = currentTab?.content || null;
+  return (
+    <section className="mt-4 rounded bg-gray-800">
+      <ul className="flex flex-row">
+        {OPTIONS_ITEMS.map(({ title, slug }) => {
+          const isTabActive = currentTab?.slug === slug;
+          return (
+            <li key={slug}>
+              <Link href={{ query: { ...router.query, option: slug } }}>
+                <a
+                  className={clsx(
+                    "flex mx-4 py-3",
+                    isTabActive ? "text-white border-current" : "text-gray-400",
+                  )}
+                >
+                  {title}
+                </a>
+              </Link>
+            </li>
+          );
+        })}
+      </ul>
+      {TabContent && (
+        <Suspense fallback="Loading...">
+          <TabContent />
+        </Suspense>
+      )}
+    </section>
+  );
 };
 
 export default Portifolio;

--- a/apps/dex/src/layouts/Nav/Nav.tsx
+++ b/apps/dex/src/layouts/Nav/Nav.tsx
@@ -46,7 +46,7 @@ export const MENU_ITEMS = [
 
 const Header = () => {
   const router = useRouter();
-  const currentPath = router.asPath;
+  const currentPath = router.pathname;
 
   const { data: TVL, isLoading: isLoadingTVL } = useTVLQuery();
   const { data: rowanPrice, isLoading: isLoadingRowanPrice } =
@@ -90,9 +90,7 @@ const Header = () => {
                     role="navigation"
                     className={clsx(
                       "flex items-center gap-4 p-2 hover:bg-gray-800 hover:opacity-80 rounded-md transition-all",
-                      {
-                        "bg-gray-600": currentPath === href,
-                      },
+                      { "bg-gray-600": currentPath === href },
                     )}
                   >
                     <span className="h-6 w-6 grid place-items-center text-gray-50 md:hidden">

--- a/apps/dex/src/pages/margin/index.tsx
+++ b/apps/dex/src/pages/margin/index.tsx
@@ -1,6 +1,8 @@
 import type { NextPage } from "next";
+import type { ParsedUrlQuery } from "querystring";
 
 import { TabsWithSuspense, TabsWithSuspenseProps } from "@sifchain/ui";
+import { useEffect, useState } from "react";
 import { useRouter } from "next/router";
 import dynamic from "next/dynamic";
 import Link from "next/link";
@@ -23,21 +25,48 @@ const TAB_ITEMS: TabsWithSuspenseProps["items"] = [
 
 const Margin: NextPage = () => {
   const router = useRouter();
-  const activeTab = (router.query["tab"] as string) || DEFAULT_TAB_ITEM;
-  return (
-    <PageLayout heading="Margin">
+  const [querystring, setQuerystring] = useState<ParsedUrlQuery | null>(null);
+
+  /**
+   * If a page does not have data fetching methods, router.query will be an empty object
+   * on the page's first load, when the page gets pre-generated on the server.
+   * https://nextjs.org/docs/api-reference/next/router#router-object
+   *
+   * Because of that, the nested tab flickers. For example:
+   *    /margin?tab=portifolio&option=history
+   *
+   * The above URL will NOT render the correct "History" option at first load
+   * It will render "Open positions" (hardcoded default) and then flicks to "History"
+   * This is not an ideal UX; hence, we need the sync below with router.isReady
+   */
+  useEffect(() => {
+    if (!router.isReady) {
+      return;
+    }
+    setQuerystring(router.query);
+  }, [router.isReady, router.query]);
+
+  let content = <div className="bg-gray-850 p-10 text-center">Loading...</div>;
+
+  if (querystring !== null) {
+    const activeTab = (querystring["tab"] as string) || DEFAULT_TAB_ITEM;
+    content = (
       <TabsWithSuspense
         activeTab={activeTab}
         items={TAB_ITEMS}
-        loadingFallback="Loading..."
+        loadingFallback={
+          <div className="bg-gray-850 p-10 text-center">Loading...</div>
+        }
         renderItem={(title, slug) => (
           <Link href={{ query: { tab: slug } }}>
             <a className="flex py-2">{title}</a>
           </Link>
         )}
       />
-    </PageLayout>
-  );
+    );
+  }
+
+  return <PageLayout heading="Margin">{content}</PageLayout>;
 };
 
 export default Margin;

--- a/apps/dex/src/pages/margin/index.tsx
+++ b/apps/dex/src/pages/margin/index.tsx
@@ -1,13 +1,14 @@
 import type { NextPage } from "next";
 
-import Link from "next/link";
+import { TabsWithSuspense, TabsWithSuspenseProps } from "@sifchain/ui";
 import { useRouter } from "next/router";
 import dynamic from "next/dynamic";
-import { TabsWithSuspense } from "@sifchain/ui";
+import Link from "next/link";
 
 import PageLayout from "~/layouts/PageLayout";
 
-const TAB_ITEMS = [
+const DEFAULT_TAB_ITEM = "portifolio";
+const TAB_ITEMS: TabsWithSuspenseProps["items"] = [
   {
     title: "Portifolio",
     slug: "portifolio",
@@ -22,7 +23,7 @@ const TAB_ITEMS = [
 
 const Margin: NextPage = () => {
   const router = useRouter();
-  const activeTab = (router.query["tab"] as string) || "portifolio";
+  const activeTab = (router.query["tab"] as string) || DEFAULT_TAB_ITEM;
   return (
     <PageLayout heading="Margin">
       <TabsWithSuspense


### PR DESCRIPTION
### summary

- this PR is based on https://github.com/Sifchain/sifchain-ui-next/pull/42
- lazy loading inner "Open positions" and "History" tables
- Each one of them have their own "page / component"
- Component rendering is synced with URL, making it easy to share (e.g., `/margin?tab=portifolio&option=history`)
- Using Suspense for inner loading
- Comment [added in code explaining why](https://github.com/Sifchain/sifchain-ui-next/commit/11a1fbee71eba73e4345e7c517a3717e847b8106#diff-c77280d87aab4a4d6e4c15ed1638565d8ae1e4aa1fbf284673fba323bc3afcdb) we need to add an additional sync to Next.js router, missing information between server and client routers

### screenshots
![localhost_3000_margin_tab=portifolio option=open-positions](https://user-images.githubusercontent.com/829902/178405370-f6dd7e9c-0b9b-4020-9a53-3a459702744d.png)
![localhost_3000_margin_tab=portifolio option=open-positions (1)](https://user-images.githubusercontent.com/829902/178405389-0c402721-377c-4fe8-b700-bb0d9e69cdf4.png)
![localhost_3000_margin_tab=portifolio option=open-positions (5)](https://user-images.githubusercontent.com/829902/178405403-8500e820-311b-4675-8b8b-dffd5e4ad9bd.png)
![localhost_3000_margin_tab=portifolio option=open-positions (3)](https://user-images.githubusercontent.com/829902/178405427-ad827308-42bb-44f8-b379-367c87e8e51f.png)
![localhost_3000_margin_tab=portifolio option=open-positions (4)](https://user-images.githubusercontent.com/829902/178405454-7fd607e0-aa63-4348-8633-62f308b2be9a.png)

