### PR TITLE
refactor: use browser locale

### DIFF
--- a/packages/ui/src/utils/intl.ts
+++ b/packages/ui/src/utils/intl.ts
@@ -1,4 +1,4 @@
-export const currencyFormatter = Intl.NumberFormat("en-US", {
+export const currencyFormatter = Intl.NumberFormat(undefined, {
   style: "currency",
   currency: "USD",
   minimumFractionDigits: 2,


### PR DESCRIPTION
passing `undefined`, the default locale of the JavaScript runtime is used