### PR TITLE
feat: add margin trade page html scaffolding

### DIFF
--- a/apps/dex/src/compounds/Margin/History.tsx
+++ b/apps/dex/src/compounds/Margin/History.tsx
@@ -13,9 +13,9 @@ const HISTORY_HEADER_ITEMS = [
 
 const Trade: NextPage = () => {
   return (
-    <div className="overflow-x">
+    <div className="overflow-x-auto">
       <table className="table-auto overflow-scroll w-full text-left text-xs">
-        <thead>
+        <thead className="bg-gray-800">
           <tr className="text-gray-400">
             {HISTORY_HEADER_ITEMS.map((title) => {
               return (
@@ -48,7 +48,7 @@ const Trade: NextPage = () => {
             <td className="px-4 py-3">5.00000000</td>
             <td>2x</td>
             <td className="px-4 py-3">
-              <Slug color="green" title="0.002 (0.0%)" />
+              <Slug color="red" title="-0.002 (0.0%)" />
             </td>
           </tr>
           <NoResultsTr />

--- a/apps/dex/src/compounds/Margin/OpenPositions.tsx
+++ b/apps/dex/src/compounds/Margin/OpenPositions.tsx
@@ -17,9 +17,9 @@ const OPEN_POSITIONS_HEADER_ITEMS = [
 
 const Trade: NextPage = () => {
   return (
-    <div className="overflow-x">
+    <div className="overflow-x-auto">
       <table className="table-auto overflow-scroll w-full text-left text-xs">
-        <thead>
+        <thead className="bg-gray-800">
           <tr className="text-gray-400">
             {OPEN_POSITIONS_HEADER_ITEMS.map((title) => {
               return (
@@ -56,7 +56,7 @@ const Trade: NextPage = () => {
             <td className="px-4 py-3">2x</td>
             <td className="px-4 py-3">&ndash;</td>
             <td className="px-4 py-3">
-              <Slug color="green" title="0.002 (0.0%)" />
+              <Slug color="red" title="-0.002 (0.0%)" />
             </td>
             <td className="px-4 py-3">&ndash;</td>
             <td className="px-4 py-3">&ndash;</td>

--- a/apps/dex/src/compounds/Margin/Portifolio.tsx
+++ b/apps/dex/src/compounds/Margin/Portifolio.tsx
@@ -28,8 +28,8 @@ const Portifolio: NextPage = () => {
   const TabContent = currentTab?.content || null;
 
   return (
-    <section className="mt-4 rounded bg-gray-800">
-      <ul className="flex flex-row text-sm">
+    <section className="mt-4">
+      <ul className="flex flex-row text-sm bg-gray-800 rounded-tl rounded-tr">
         {OPTIONS_ITEMS.map(({ title, slug }) => {
           const isTabActive = currentTab?.slug === slug;
           return (

--- a/apps/dex/src/compounds/Margin/Trade.tsx
+++ b/apps/dex/src/compounds/Margin/Trade.tsx
@@ -1,7 +1,51 @@
 import type { NextPage } from "next";
 
+import { Slug } from "~/components/Slug";
+
 const Trade: NextPage = () => {
-  return <h1>Trade Page</h1>;
+  return (
+    <>
+      <section className="p-4 grid grid-cols-7 gap-x-5 justify-items-end text-xs">
+        <ul className="col-span-2 w-full flex flex-col">
+          <li className="text-gray-300 pb-2">Pool Overview</li>
+          <li className="flex-1 flex items-center">
+            <select className="flex-1 text-xs bg-gray-700 rounded border-0">
+              <option>ETH / ROWAN</option>
+            </select>
+          </li>
+        </ul>
+        <ul className="flex flex-col">
+          <li className="text-gray-300 pb-2">Pool</li>
+          <li className="flex-1 flex items-center font-semibold">
+            $100,000,000
+          </li>
+        </ul>
+        <ul className="flex flex-col">
+          <li className="text-gray-300 pb-2">ETH/ROWAN Volume</li>
+          <li className="flex-1 flex items-center font-semibold">$2,000,000</li>
+        </ul>
+        <ul className="flex flex-col">
+          <li className="text-gray-300 pb-2">ETH Price</li>
+          <li className="flex-1 flex items-center font-semibold">
+            <span className="mr-2">$1,000</span>
+            <Slug color="green" title={`(-1.3%)`} />
+          </li>
+        </ul>
+        <ul className="flex flex-col">
+          <li className="text-gray-300 pb-2">ROWAN Price</li>
+          <li className="flex-1 flex items-center font-semibold">
+            <span className="mr-2">$.006</span>
+            <Slug color="red" title={`(+2.3%)`} />
+          </li>
+        </ul>
+        <ul className="flex flex-col">
+          <li className="text-gray-300 pb-2">Pool Health</li>
+          <li className="flex-1 flex items-center font-semibold">&ndash;</li>
+        </ul>
+      </section>
+      <section className="p-4 grid grid-cols-2 gap-x-6 text-xs"></section>
+    </>
+  );
 };
 
 export default Trade;

--- a/apps/dex/src/compounds/Margin/Trade.tsx
+++ b/apps/dex/src/compounds/Margin/Trade.tsx
@@ -1,11 +1,27 @@
 import type { NextPage } from "next";
 
+import clsx from "clsx";
+
+import { Button, ButtonGroup } from "@sifchain/ui";
 import { Slug } from "~/components/Slug";
+import { useState } from "react";
+
+const OPEN_POSITIONS_HEADER_ITEMS = [
+  "Pool",
+  "Side",
+  "Amount",
+  "Leverage",
+  "BP used",
+  "Unrealized P&L",
+  "Funding rate %",
+  "Unsettled Interest",
+  "Position health",
+];
 
 const Trade: NextPage = () => {
   return (
     <>
-      <section className="p-4 grid grid-cols-7 gap-x-5 justify-items-end text-xs">
+      <section className="box-golden-border rounded p-4 mt-4 grid grid-cols-7 gap-x-5 justify-items-end text-xs">
         <ul className="col-span-2 w-full flex flex-col">
           <li className="text-gray-300 pb-2">Pool Overview</li>
           <li className="flex-1 flex items-center">
@@ -28,14 +44,14 @@ const Trade: NextPage = () => {
           <li className="text-gray-300 pb-2">ETH Price</li>
           <li className="flex-1 flex items-center font-semibold">
             <span className="mr-2">$1,000</span>
-            <Slug color="green" title={`(-1.3%)`} />
+            <Slug color="red" title={`(-1.3%)`} />
           </li>
         </ul>
         <ul className="flex flex-col">
           <li className="text-gray-300 pb-2">ROWAN Price</li>
           <li className="flex-1 flex items-center font-semibold">
             <span className="mr-2">$.006</span>
-            <Slug color="red" title={`(+2.3%)`} />
+            <Slug color="green" title={`(+2.3%)`} />
           </li>
         </ul>
         <ul className="flex flex-col">
@@ -43,7 +59,247 @@ const Trade: NextPage = () => {
           <li className="flex-1 flex items-center font-semibold">&ndash;</li>
         </ul>
       </section>
-      <section className="p-4 grid grid-cols-2 gap-x-6 text-xs"></section>
+      <section className="mt-4 text-xs grid grid-cols-7 gap-x-2">
+        <aside className="box-golden-border rounded p-4 col-span-2 flex flex-col">
+          <ul className="box-golden-border-bottom pb-4 flex flex-col gap-4">
+            <li>
+              <div className="flex flex-row">
+                <span className="font-semibold mr-auto min-w-fit">
+                  Account Balance
+                </span>
+                <span>$50,000 &rarr; $49,000</span>
+              </div>
+            </li>
+            <li>
+              <div className="flex flex-row">
+                <span className="font-semibold mr-auto min-w-fit">
+                  Collateral Balance
+                </span>
+                <span>$5,000 &rarr; $4,000</span>
+              </div>
+              <p className="text-gray-400 text-xs w-full text-right">
+                40,000 ROWAN &rarr; 40,000 ROWAN
+              </p>
+            </li>
+            <li>
+              <div className="flex flex-row">
+                <span className="font-semibold mr-auto min-w-fit">
+                  Total Borrowed
+                </span>
+                <span>$10,000 &rarr; $11,000</span>
+              </div>
+              <p className="text-gray-400 text-xs w-full text-right">
+                100,000 ROWAN &rarr; 100,000 ROWAN
+              </p>
+            </li>
+          </ul>
+          <ul className="box-golden-border-bottom py-4 flex flex-col gap-4">
+            <li className="flex flex-col">
+              <span className="text-xs text-gray-300 mb-1">Collateral</span>
+              <div className="grid grid-cols-2 gap-2">
+                <select className="text-xs bg-gray-700 rounded border-0">
+                  <option>ROWAN</option>
+                </select>
+                <input
+                  type="text"
+                  defaultValue="100,000"
+                  className="text-xs bg-gray-700 rounded border-0"
+                />
+              </div>
+              <span className="text-gray-200 text-right mt-1">
+                &#61; $1,000
+              </span>
+            </li>
+            <li className="flex flex-col">
+              <span className="text-xs text-gray-300 mb-1">Position</span>
+              <div className="grid grid-cols-2 gap-2">
+                <select className="text-xs bg-gray-700 rounded border-0">
+                  <option>ETH</option>
+                </select>
+                <input
+                  type="text"
+                  defaultValue="1"
+                  className="text-xs bg-gray-700 rounded border-0"
+                />
+              </div>
+              <span className="text-gray-200 text-right mt-1">
+                &#61; $2,000
+              </span>
+            </li>
+            <li className="flex flex-col">
+              <span className="text-xs text-gray-300 mb-1">
+                <span className="mr-1">Leverage</span>
+                <span className="text-gray-400">Up to 2x</span>
+              </span>
+              <div className="grid grid-cols-6 gap-2">
+                <input
+                  type="text"
+                  defaultValue="2x"
+                  className="text-xs bg-gray-700 rounded border-0 col-span-3"
+                />
+                <Button variant="secondary" as="button" size="xs">
+                  1x
+                </Button>
+                <Button variant="secondary" as="button" size="xs">
+                  1.5x
+                </Button>
+                <Button variant="secondary" as="button" size="xs">
+                  2x
+                </Button>
+              </div>
+              <div className="grid grid-cols-2 font-semibold mt-2">
+                <label
+                  htmlFor="inputSideLong"
+                  className="flex flex-row cursor-pointer"
+                >
+                  <input
+                    type="radio"
+                    id="inputSideLong"
+                    name="marginSide"
+                    className="sr-only"
+                    defaultChecked={true}
+                  />
+                  <span className="flex-1 text-center p-2 rounded-tl rounded-bl">
+                    Long
+                  </span>
+                </label>
+                <label
+                  htmlFor="inputSideShort"
+                  className="flex flex-row cursor-pointer"
+                >
+                  <input
+                    type="radio"
+                    id="inputSideShort"
+                    name="marginSide"
+                    className="sr-only"
+                  />
+                  <span className="flex-1 text-center p-2 rounded-tr rounded-br">
+                    Short
+                  </span>
+                </label>
+              </div>
+            </li>
+            <li className="grid grid-cols-4 gap-2">
+              <Button
+                variant="primary"
+                as="button"
+                size="md"
+                className="col-span-3 rounded"
+              >
+                Place buy order
+              </Button>
+              <Button
+                variant="outline"
+                as="button"
+                size="sm"
+                className="ring-1 rounded self-center"
+              >
+                Clear
+              </Button>
+            </li>
+          </ul>
+          <ul className="pt-4 flex flex-col gap-4">
+            <li>
+              <div className="flex flex-row">
+                <span className="font-semibold mr-auto min-w-fit">
+                  Collateral Balance
+                </span>
+                <span>$1,000 </span>
+              </div>
+              <p className="text-gray-400 text-xs w-full text-right">
+                50,000 ROWAN
+              </p>
+            </li>
+            <li>
+              <div className="flex flex-row">
+                <span className="font-semibold mr-auto min-w-fit">
+                  Borrow Amount
+                </span>
+                <span>$1,000</span>
+              </div>
+              <p className="text-gray-400 text-xs w-full text-right">
+                100,000 ROWAN
+              </p>
+            </li>
+            <li>
+              <div className="flex flex-row">
+                <span className="font-semibold mr-auto min-w-fit">
+                  Overall Position
+                </span>
+                <span>$2,000</span>
+              </div>
+              <p className="text-gray-400 text-xs w-full text-right">2ETH</p>
+            </li>
+            <li>
+              <div className="flex flex-row">
+                <span className="font-semibold mr-auto min-w-fit">
+                  Trade Fees
+                </span>
+                <span>&minus;$50</span>
+              </div>
+              <p className="text-gray-400 text-xs w-full text-right">
+                .0005 ETH
+              </p>
+            </li>
+            <li>
+              <div className="flex flex-row">
+                <span className="font-semibold mr-auto min-w-fit">
+                  Resulting Position
+                </span>
+                <span>$1,900</span>
+              </div>
+              <p className="text-gray-400 text-xs w-full text-right">1.9 ETH</p>
+            </li>
+          </ul>
+        </aside>
+        <section className="col-span-5 overflow-x-auto rounded-tl rounded-tr">
+          <table className="table-auto overflow-scroll w-full text-left text-xs">
+            <thead className="bg-gray-800">
+              <tr className="text-gray-400">
+                {OPEN_POSITIONS_HEADER_ITEMS.map((title) => {
+                  return (
+                    <th key={title} className="font-normal px-4 py-3">
+                      {title}
+                    </th>
+                  );
+                })}
+              </tr>
+            </thead>
+            <tbody className="bg-gray-850">
+              <tr>
+                <td className="px-4 py-3">ETH / ROWAN</td>
+                <td className="px-4 py-3">
+                  <Slug color="green" title="Long" />
+                </td>
+                <td className="px-4 py-3">5.00000000</td>
+                <td className="px-4 py-3">2x</td>
+                <td className="px-4 py-3">&ndash;</td>
+                <td className="px-4 py-3">
+                  <Slug color="green" title="0.002 (0.0%)" />
+                </td>
+                <td className="px-4 py-3">&ndash;</td>
+                <td className="px-4 py-3">&ndash;</td>
+                <td className="px-4 py-3">&ndash;</td>
+              </tr>
+              <tr>
+                <td className="px-4 py-3">ETH / ROWAN</td>
+                <td className="px-4 py-3">
+                  <Slug color="red" title="Short" />
+                </td>
+                <td className="px-4 py-3">5.00000000</td>
+                <td className="px-4 py-3">2x</td>
+                <td className="px-4 py-3">&ndash;</td>
+                <td className="px-4 py-3">
+                  <Slug color="green" title="0.002 (0.0%)" />
+                </td>
+                <td className="px-4 py-3">&ndash;</td>
+                <td className="px-4 py-3">&ndash;</td>
+                <td className="px-4 py-3">&ndash;</td>
+              </tr>
+            </tbody>
+          </table>
+        </section>
+      </section>
     </>
   );
 };

--- a/apps/dex/src/styles/globals.css
+++ b/apps/dex/src/styles/globals.css
@@ -1,1 +1,13 @@
 @import url("@sifchain/ui/src/base.css");
+
+.box-golden-border {
+  border-color: #322f23;
+  border-style: solid;
+  border-width: 1px;
+}
+
+.box-golden-border-bottom {
+  border-bottom-color: #322f23;
+  border-bottom-style: solid;
+  border-bottom-width: 1px;
+}

--- a/packages/ui/src/base.css
+++ b/packages/ui/src/base.css
@@ -43,4 +43,23 @@
   .input-label {
     @apply text-gray-200 text-sm font-normal;
   }
+
+  #inputSideLong + span,
+  #inputSideShort + span {
+    @apply bg-gray-800 text-gray-700;
+  }
+  #inputSideLong + span:hover,
+  #inputSideShort + span:hover {
+    @apply bg-gray-750 text-gray-500 ring-1 ring-cyan-500 z-20;
+  }
+  #inputSideLong:checked + span {
+    @apply bg-gray-700 text-gray-200 rounded-tr rounded-br z-10;
+  }
+  #inputSideShort:checked + span {
+    @apply bg-gray-700 text-gray-200 rounded-tl rounded-bl z-10;
+  }
+  #inputSideLong:checked + span:hover,
+  #inputSideShort:checked + span:hover {
+    @apply bg-gray-600 text-gray-100;
+  }
 }


### PR DESCRIPTION
### summary
- PR based on branch from https://github.com/Sifchain/sifchain-ui-next/pull/42
- fix: table overflow-x in "Margin > Portifolio" in `History.tsx`, `OpenPositions.tsx`
- fix: table heading color in "Margin > Portifolio" in `History.tsx`, `OpenPositions.tsx`, making it similar to "Margin > Trade"
- feat: add pool overview in commit https://github.com/Sifchain/sifchain-ui-next/commit/8291b222e6462d60b286099bff76073e026bf577
![Screen Shot 2022-07-13 at 9 43 31 PM](https://user-images.githubusercontent.com/829902/178703952-4705b196-4d4a-4381-b99f-cd6aebdf9444.png)
- feat: add remaining page components in commit https://github.com/Sifchain/sifchain-ui-next/commit/567a0f92699d839b6965ba412acef3767c707237
![Screen Shot 2022-07-13 at 9 44 33 PM](https://user-images.githubusercontent.com/829902/178704139-aa9cfe13-f0e6-45c0-8f54-f515f243d8ad.png)

### questions
- two new CSS definitions
- `apps/dex/src/styles/globals.css`: utility to add a border with a new color not in the UI theme
- `packages/ui/src/base.css`: selectors to add style for the Long/Short button group
- I'm not 100% sure of the final destination here. Let's bounce ideas and see where they should live before the release!

### screenview

[Sichain-Dex---Margin.webm](https://user-images.githubusercontent.com/829902/178703087-47da6457-fda9-4380-8947-09a6cd008eaa.webm)

### pending

- Mostly, the "smart selectors" are missing compared to Figma's design
- I'm using HTML Select elements in this PR
- I'll schedule a meeting to understand the implementation with you folks 👍 

![Screen Shot 2022-07-13 at 9 52 11 PM](https://user-images.githubusercontent.com/829902/178705746-30285cf0-071d-4147-9a46-b2f675a11eca.png)
 