### PR TITLE
feat: match Portifolio and Trade tables header to Margin Metrics Spreadsheet

### DIFF
--- a/apps/dex/src/compounds/Margin/History.tsx
+++ b/apps/dex/src/compounds/Margin/History.tsx
@@ -3,11 +3,12 @@ import type { NextPage } from "next";
 import { Slug } from "~/components/Slug";
 
 const HISTORY_HEADER_ITEMS = [
-  "Date",
+  "Date closed",
+  "Time open",
   "Pool",
   "Side",
+  "Asset",
   "Amount",
-  "Leverage",
   "Realized P&L",
 ];
 
@@ -38,6 +39,7 @@ const Trade: NextPage = () => {
             <td className="px-4 py-3">
               <Slug color="green" title="0.002 (0.0%)" />
             </td>
+            <td className="px-4 py-3">&ndash;</td>
           </tr>
           <tr>
             <td className="px-4 py-3">07-05 11:23:51 AM</td>
@@ -50,6 +52,7 @@ const Trade: NextPage = () => {
             <td className="px-4 py-3">
               <Slug color="red" title="-0.002 (0.0%)" />
             </td>
+            <td className="px-4 py-3">&ndash;</td>
           </tr>
           <NoResultsTr />
         </tbody>

--- a/apps/dex/src/compounds/Margin/History.tsx
+++ b/apps/dex/src/compounds/Margin/History.tsx
@@ -1,5 +1,3 @@
-import type { NextPage } from "next";
-
 import { Slug } from "~/components/Slug";
 
 const HISTORY_HEADER_ITEMS = [
@@ -12,7 +10,7 @@ const HISTORY_HEADER_ITEMS = [
   "Realized P&L",
 ];
 
-const Trade: NextPage = () => {
+const HistoryTable = () => {
   return (
     <div className="overflow-x-auto">
       <table className="table-auto overflow-scroll w-full text-left text-xs">
@@ -74,4 +72,4 @@ function NoResultsTr() {
   );
 }
 
-export default Trade;
+export default HistoryTable;

--- a/apps/dex/src/compounds/Margin/History.tsx
+++ b/apps/dex/src/compounds/Margin/History.tsx
@@ -27,30 +27,30 @@ const HistoryTable = () => {
         </thead>
         <tbody className="bg-gray-850">
           <tr>
-            <td className="px-4 py-3">07-05 11:23:51 AM</td>
+            <td className="px-4 py-3">2022-07-12</td>
+            <td className="px-4 py-3">2 days, 5 hrs, 2 mins</td>
             <td className="px-4 py-3">ETH / ROWAN</td>
             <td className="px-4 py-3">
               <Slug color="green" title="Long" />
             </td>
-            <td className="px-4 py-3">5.00000000</td>
-            <td>2x</td>
+            <td>ETH</td>
+            <td className="px-4 py-3">2.5</td>
             <td className="px-4 py-3">
-              <Slug color="green" title="0.002 (0.0%)" />
+              <Slug color="green" title="$2,000.15" />
             </td>
-            <td className="px-4 py-3">&ndash;</td>
           </tr>
           <tr>
-            <td className="px-4 py-3">07-05 11:23:51 AM</td>
+            <td className="px-4 py-3">2022-07-12</td>
+            <td className="px-4 py-3">2 days, 5 hrs, 2 mins</td>
             <td className="px-4 py-3">ETH / ROWAN</td>
             <td className="px-4 py-3">
               <Slug color="red" title="Short" />
             </td>
-            <td className="px-4 py-3">5.00000000</td>
-            <td>2x</td>
+            <td>ETH</td>
+            <td className="px-4 py-3">2.5</td>
             <td className="px-4 py-3">
-              <Slug color="red" title="-0.002 (0.0%)" />
+              <Slug color="red" title="-$2,000.15" />
             </td>
-            <td className="px-4 py-3">&ndash;</td>
           </tr>
           <NoResultsTr />
         </tbody>

--- a/apps/dex/src/compounds/Margin/OpenPositions.tsx
+++ b/apps/dex/src/compounds/Margin/OpenPositions.tsx
@@ -5,14 +5,17 @@ import { Slug } from "~/components/Slug";
 const OPEN_POSITIONS_HEADER_ITEMS = [
   "Pool",
   "Side",
+  "Asset",
   "Amount",
-  "Leverage",
-  "BP used",
+  "Base Leverage",
   "Unrealized P&L",
-  "Funding rate %",
+  "Interest Rate",
   "Unsettled Interest",
-  "Position health",
-  "Close all",
+  "Next Payment",
+  "Paid Interest",
+  "Health",
+  "Date Opened",
+  "Time Open",
 ];
 
 const Trade: NextPage = () => {
@@ -46,6 +49,9 @@ const Trade: NextPage = () => {
             <td className="px-4 py-3">&ndash;</td>
             <td className="px-4 py-3">&ndash;</td>
             <td className="px-4 py-3">Close</td>
+            <td className="px-4 py-3">&ndash;</td>
+            <td className="px-4 py-3">&ndash;</td>
+            <td className="px-4 py-3">&ndash;</td>
           </tr>
           <tr>
             <td className="px-4 py-3">ETH / ROWAN</td>
@@ -62,6 +68,9 @@ const Trade: NextPage = () => {
             <td className="px-4 py-3">&ndash;</td>
             <td className="px-4 py-3">&ndash;</td>
             <td className="px-4 py-3">Close</td>
+            <td className="px-4 py-3">&ndash;</td>
+            <td className="px-4 py-3">&ndash;</td>
+            <td className="px-4 py-3">&ndash;</td>
           </tr>
           <NoResultsTr />
         </tbody>

--- a/apps/dex/src/compounds/Margin/OpenPositions.tsx
+++ b/apps/dex/src/compounds/Margin/OpenPositions.tsx
@@ -1,5 +1,3 @@
-import type { NextPage } from "next";
-
 import { Slug } from "~/components/Slug";
 
 const OPEN_POSITIONS_HEADER_ITEMS = [
@@ -16,17 +14,52 @@ const OPEN_POSITIONS_HEADER_ITEMS = [
   "Health",
   "Date Opened",
   "Time Open",
-];
+] as const;
 
-const Trade: NextPage = () => {
+type HideColsUnion =
+  | "pool"
+  | "side"
+  | "asset"
+  | "amount"
+  | "base-leverage"
+  | "unrealized-p-l"
+  | "interest-rate"
+  | "unsettled-interest"
+  | "next-payment"
+  | "paid-interest"
+  | "health"
+  | "date-opened"
+  | "time-open";
+type OpenPositionsTableProps = {
+  hideCols?: HideColsUnion[];
+};
+const OpenPositionsTable = (props: OpenPositionsTableProps) => {
+  const { hideCols } = props;
+  let cols = [...OPEN_POSITIONS_HEADER_ITEMS];
+
+  if (typeof hideCols !== "undefined") {
+    cols = cols.filter((col) => {
+      const itemKey = fromColNameToItemKey(col);
+      if (hideCols.includes(itemKey)) {
+        return false;
+      }
+      return true;
+    });
+  }
+
   return (
     <div className="overflow-x-auto">
       <table className="table-auto overflow-scroll w-full text-left text-xs">
         <thead className="bg-gray-800">
           <tr className="text-gray-400">
-            {OPEN_POSITIONS_HEADER_ITEMS.map((title) => {
+            {cols.map((title) => {
+              const itemKey = fromColNameToItemKey(title);
               return (
-                <th key={title} className="font-normal px-4 py-3">
+                <th
+                  key={itemKey}
+                  data-item-key={itemKey}
+                  className="font-normal px-4 py-3"
+                >
                   {title}
                 </th>
               );
@@ -49,9 +82,15 @@ const Trade: NextPage = () => {
             <td className="px-4 py-3">&ndash;</td>
             <td className="px-4 py-3">&ndash;</td>
             <td className="px-4 py-3">Close</td>
-            <td className="px-4 py-3">&ndash;</td>
-            <td className="px-4 py-3">&ndash;</td>
-            <td className="px-4 py-3">&ndash;</td>
+            <td className="px-4 py-3" hidden={Boolean(hideCols)}>
+              &ndash;
+            </td>
+            <td className="px-4 py-3" hidden={Boolean(hideCols)}>
+              &ndash;
+            </td>
+            <td className="px-4 py-3" hidden={Boolean(hideCols)}>
+              &ndash;
+            </td>
           </tr>
           <tr>
             <td className="px-4 py-3">ETH / ROWAN</td>
@@ -68,28 +107,38 @@ const Trade: NextPage = () => {
             <td className="px-4 py-3">&ndash;</td>
             <td className="px-4 py-3">&ndash;</td>
             <td className="px-4 py-3">Close</td>
-            <td className="px-4 py-3">&ndash;</td>
-            <td className="px-4 py-3">&ndash;</td>
-            <td className="px-4 py-3">&ndash;</td>
+            <td className="px-4 py-3" hidden={Boolean(hideCols)}>
+              &ndash;
+            </td>
+            <td className="px-4 py-3" hidden={Boolean(hideCols)}>
+              &ndash;
+            </td>
+            <td className="px-4 py-3" hidden={Boolean(hideCols)}>
+              &ndash;
+            </td>
           </tr>
-          <NoResultsTr />
+          <NoResultsTr colSpan={cols.length} />
         </tbody>
       </table>
     </div>
   );
 };
 
-function NoResultsTr() {
+type NoResultsTrProps = {
+  colSpan: number;
+};
+function NoResultsTr(props: NoResultsTrProps) {
   return (
     <tr>
-      <td
-        colSpan={OPEN_POSITIONS_HEADER_ITEMS.length}
-        className="text-gray-400 text-center p-20"
-      >
+      <td colSpan={props.colSpan} className="text-gray-400 text-center p-20">
         You have no open positions.
       </td>
     </tr>
   );
 }
 
-export default Trade;
+function fromColNameToItemKey(name: string) {
+  return name.toLocaleLowerCase().replace(/[^a-z]+/g, "-") as HideColsUnion;
+}
+
+export default OpenPositionsTable;

--- a/apps/dex/src/compounds/Margin/OpenPositions.tsx
+++ b/apps/dex/src/compounds/Margin/OpenPositions.tsx
@@ -72,24 +72,24 @@ const OpenPositionsTable = (props: OpenPositionsTableProps) => {
             <td className="px-4 py-3">
               <Slug color="green" title="Long" />
             </td>
-            <td className="px-4 py-3">5.00000000</td>
-            <td className="px-4 py-3">2x</td>
-            <td className="px-4 py-3">&ndash;</td>
+            <td className="px-4 py-3">ETH</td>
+            <td className="px-4 py-3">2.5</td>
+            <td className="px-4 py-3">1.9x</td>
             <td className="px-4 py-3">
-              <Slug color="green" title="0.002 (0.0%)" />
+              <Slug color="green" title="$2,000.15" />
             </td>
-            <td className="px-4 py-3">&ndash;</td>
-            <td className="px-4 py-3">&ndash;</td>
-            <td className="px-4 py-3">&ndash;</td>
-            <td className="px-4 py-3">Close</td>
+            <td className="px-4 py-3">18.52%</td>
+            <td className="px-4 py-3">$10.25</td>
+            <td className="px-4 py-3">2 hrs, 5 mins</td>
+            <td className="px-4 py-3">$80.15</td>
             <td className="px-4 py-3" hidden={Boolean(hideCols)}>
               &ndash;
             </td>
             <td className="px-4 py-3" hidden={Boolean(hideCols)}>
-              &ndash;
+              2022-07-12
             </td>
             <td className="px-4 py-3" hidden={Boolean(hideCols)}>
-              &ndash;
+              5 hrs
             </td>
           </tr>
           <tr>
@@ -97,24 +97,24 @@ const OpenPositionsTable = (props: OpenPositionsTableProps) => {
             <td className="px-4 py-3">
               <Slug color="red" title="Short" />
             </td>
-            <td className="px-4 py-3">5.00000000</td>
-            <td className="px-4 py-3">2x</td>
-            <td className="px-4 py-3">&ndash;</td>
+            <td className="px-4 py-3">ETH</td>
+            <td className="px-4 py-3">2.5</td>
+            <td className="px-4 py-3">1.9x</td>
             <td className="px-4 py-3">
-              <Slug color="red" title="-0.002 (0.0%)" />
+              <Slug color="red" title="-$2,000.15" />
             </td>
-            <td className="px-4 py-3">&ndash;</td>
-            <td className="px-4 py-3">&ndash;</td>
-            <td className="px-4 py-3">&ndash;</td>
-            <td className="px-4 py-3">Close</td>
+            <td className="px-4 py-3">18.52%</td>
+            <td className="px-4 py-3">$10.25</td>
+            <td className="px-4 py-3">2 hrs, 5 mins</td>
+            <td className="px-4 py-3">$80.15</td>
             <td className="px-4 py-3" hidden={Boolean(hideCols)}>
               &ndash;
             </td>
             <td className="px-4 py-3" hidden={Boolean(hideCols)}>
-              &ndash;
+              2022-07-12
             </td>
             <td className="px-4 py-3" hidden={Boolean(hideCols)}>
-              &ndash;
+              5 hrs
             </td>
           </tr>
           <NoResultsTr colSpan={cols.length} />

--- a/apps/dex/src/compounds/Margin/Trade.tsx
+++ b/apps/dex/src/compounds/Margin/Trade.tsx
@@ -1,22 +1,8 @@
 import type { NextPage } from "next";
 
-import clsx from "clsx";
-
-import { Button, ButtonGroup } from "@sifchain/ui";
+import { Button } from "@sifchain/ui";
 import { Slug } from "~/components/Slug";
-import { useState } from "react";
-
-const OPEN_POSITIONS_HEADER_ITEMS = [
-  "Pool",
-  "Side",
-  "Amount",
-  "Leverage",
-  "BP used",
-  "Unrealized P&L",
-  "Funding rate %",
-  "Unsettled Interest",
-  "Position health",
-];
+import OpenPositionsTable from "~/compounds/Margin/OpenPositions";
 
 const Trade: NextPage = () => {
   return (
@@ -252,52 +238,10 @@ const Trade: NextPage = () => {
             </li>
           </ul>
         </aside>
-        <section className="col-span-5 overflow-x-auto rounded-tl rounded-tr">
-          <table className="table-auto overflow-scroll w-full text-left text-xs">
-            <thead className="bg-gray-800">
-              <tr className="text-gray-400">
-                {OPEN_POSITIONS_HEADER_ITEMS.map((title) => {
-                  return (
-                    <th key={title} className="font-normal px-4 py-3">
-                      {title}
-                    </th>
-                  );
-                })}
-              </tr>
-            </thead>
-            <tbody className="bg-gray-850">
-              <tr>
-                <td className="px-4 py-3">ETH / ROWAN</td>
-                <td className="px-4 py-3">
-                  <Slug color="green" title="Long" />
-                </td>
-                <td className="px-4 py-3">5.00000000</td>
-                <td className="px-4 py-3">2x</td>
-                <td className="px-4 py-3">&ndash;</td>
-                <td className="px-4 py-3">
-                  <Slug color="green" title="0.002 (0.0%)" />
-                </td>
-                <td className="px-4 py-3">&ndash;</td>
-                <td className="px-4 py-3">&ndash;</td>
-                <td className="px-4 py-3">&ndash;</td>
-              </tr>
-              <tr>
-                <td className="px-4 py-3">ETH / ROWAN</td>
-                <td className="px-4 py-3">
-                  <Slug color="red" title="Short" />
-                </td>
-                <td className="px-4 py-3">5.00000000</td>
-                <td className="px-4 py-3">2x</td>
-                <td className="px-4 py-3">&ndash;</td>
-                <td className="px-4 py-3">
-                  <Slug color="green" title="0.002 (0.0%)" />
-                </td>
-                <td className="px-4 py-3">&ndash;</td>
-                <td className="px-4 py-3">&ndash;</td>
-                <td className="px-4 py-3">&ndash;</td>
-              </tr>
-            </tbody>
-          </table>
+        <section className="col-span-5 rounded-tl rounded-tr">
+          <OpenPositionsTable
+            hideCols={["unsettled-interest", "next-payment", "paid-interest"]}
+          />
         </section>
       </section>
     </>

--- a/apps/dex/src/compounds/Margin/Trade.tsx
+++ b/apps/dex/src/compounds/Margin/Trade.tsx
@@ -165,24 +165,6 @@ const Trade: NextPage = () => {
                 </label>
               </div>
             </li>
-            <li className="grid grid-cols-4 gap-2">
-              <Button
-                variant="primary"
-                as="button"
-                size="md"
-                className="col-span-3 rounded"
-              >
-                Place buy order
-              </Button>
-              <Button
-                variant="outline"
-                as="button"
-                size="sm"
-                className="ring-1 rounded self-center"
-              >
-                Clear
-              </Button>
-            </li>
           </ul>
           <ul className="pt-4 flex flex-col gap-4">
             <li>
@@ -235,6 +217,24 @@ const Trade: NextPage = () => {
                 <span>$1,900</span>
               </div>
               <p className="text-gray-400 text-xs w-full text-right">1.9 ETH</p>
+            </li>
+            <li className="grid grid-cols-4 gap-2">
+              <Button
+                variant="primary"
+                as="button"
+                size="md"
+                className="col-span-3 rounded"
+              >
+                Place buy order
+              </Button>
+              <Button
+                variant="outline"
+                as="button"
+                size="sm"
+                className="ring-1 rounded self-center"
+              >
+                Clear
+              </Button>
             </li>
           </ul>
         </aside>


### PR DESCRIPTION
### summary

- updating HTML scaffolding table headers to match the metrics in Sifchain Margin Metrics