### PR TITLE
feat: add TwinRadioButton to sifchain/ui

### DIFF
--- a/apps/dex/src/compounds/Margin/Trade.tsx
+++ b/apps/dex/src/compounds/Margin/Trade.tsx
@@ -1,6 +1,6 @@
 import type { NextPage } from "next";
 
-import { Button } from "@sifchain/ui";
+import { Button, TwinRadioGroup } from "@sifchain/ui";
 import { Slug } from "~/components/Slug";
 import OpenPositionsTable from "~/compounds/Margin/OpenPositions";
 
@@ -133,37 +133,20 @@ const Trade: NextPage = () => {
                   2x
                 </Button>
               </div>
-              <div className="grid grid-cols-2 font-semibold mt-2">
-                <label
-                  htmlFor="inputSideLong"
-                  className="flex flex-row cursor-pointer"
-                >
-                  <input
-                    type="radio"
-                    id="inputSideLong"
-                    name="marginSide"
-                    className="sr-only"
-                    defaultChecked={true}
-                  />
-                  <span className="flex-1 text-center p-2 rounded-tl rounded-bl">
-                    Long
-                  </span>
-                </label>
-                <label
-                  htmlFor="inputSideShort"
-                  className="flex flex-row cursor-pointer"
-                >
-                  <input
-                    type="radio"
-                    id="inputSideShort"
-                    name="marginSide"
-                    className="sr-only"
-                  />
-                  <span className="flex-1 text-center p-2 rounded-tr rounded-br">
-                    Short
-                  </span>
-                </label>
-              </div>
+              <TwinRadioGroup
+                className="mt-2"
+                name="margin-side"
+                options={[
+                  {
+                    title: "Long",
+                    value: "long",
+                  },
+                  {
+                    title: "Short",
+                    value: "short",
+                  },
+                ]}
+              />
             </li>
           </ul>
           <ul className="pt-4 flex flex-col gap-4">

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -11,7 +11,7 @@
     "tailwind.config.preset.js"
   ],
   "scripts": {
-    "storybook": "start-storybook -p 6006",
+    "storybook": "start-storybook -p 6006 --no-open",
     "build-storybook": "build-storybook",
     "codegen:component": "node ./scripts/codegen.mjs component --",
     "svgr": "svgr ./assets/icons"

--- a/packages/ui/src/base.css
+++ b/packages/ui/src/base.css
@@ -43,23 +43,4 @@
   .input-label {
     @apply text-gray-200 text-sm font-normal;
   }
-
-  #inputSideLong + span,
-  #inputSideShort + span {
-    @apply bg-gray-800 text-gray-700;
-  }
-  #inputSideLong + span:hover,
-  #inputSideShort + span:hover {
-    @apply bg-gray-750 text-gray-500 ring-1 ring-cyan-500 z-20;
-  }
-  #inputSideLong:checked + span {
-    @apply bg-gray-700 text-gray-200 rounded-tr rounded-br z-10;
-  }
-  #inputSideShort:checked + span {
-    @apply bg-gray-700 text-gray-200 rounded-tl rounded-bl z-10;
-  }
-  #inputSideLong:checked + span:hover,
-  #inputSideShort:checked + span:hover {
-    @apply bg-gray-600 text-gray-100;
-  }
 }

--- a/packages/ui/src/components/TwinRadioGroup/TwinRadioGroup.stories.tsx
+++ b/packages/ui/src/components/TwinRadioGroup/TwinRadioGroup.stories.tsx
@@ -1,0 +1,59 @@
+import type { ComponentStory, ComponentMeta } from "@storybook/react";
+import { useState } from "react";
+
+import { TwinRadioGroup } from ".";
+
+export default {
+  title: "components/TwinRadioGroup",
+  component: TwinRadioGroup,
+} as ComponentMeta<typeof TwinRadioGroup>;
+
+export const Uncontrolled: ComponentStory<typeof TwinRadioGroup> = ({
+  name,
+  options,
+}) => {
+  return (
+    <form
+      onSubmit={(event) => {
+        event.preventDefault();
+        const $form = event.target as HTMLFormElement;
+        console.log($form["margin-side-uncontrolled"].value);
+      }}
+    >
+      <p>Using with HTML Form</p>
+      <TwinRadioGroup name={name} options={options} />
+      <button type="submit">Submit</button>
+    </form>
+  );
+};
+Uncontrolled.args = {
+  name: "margin-side-uncontrolled",
+  options: [
+    {
+      title: "Long",
+      value: "long",
+    },
+    {
+      title: "Short",
+      value: "short",
+    },
+  ],
+};
+
+export const Controlled: ComponentStory<typeof TwinRadioGroup> = (args) => {
+  const [side, setSide] = useState("short");
+  return <TwinRadioGroup {...args} onChange={setSide} value={side} />;
+};
+Controlled.args = {
+  name: "margin-side-controlled",
+  options: [
+    {
+      title: "Long",
+      value: "long",
+    },
+    {
+      title: "Short",
+      value: "short",
+    },
+  ],
+};

--- a/packages/ui/src/components/TwinRadioGroup/TwinRadioGroup.tsx
+++ b/packages/ui/src/components/TwinRadioGroup/TwinRadioGroup.tsx
@@ -1,0 +1,71 @@
+import type { FC } from "react";
+
+import { useState, useEffect } from "react";
+import { RadioGroup } from "@headlessui/react";
+import clsx from "clsx";
+
+export type TwinRadioGroup = {
+  options: {
+    title: string;
+    value: string;
+  }[];
+  value?: string;
+  onChange?: undefined | null | ((value: string) => void);
+  name: string;
+};
+
+export const TwinRadioGroup: FC<TwinRadioGroup> = (props) => {
+  let initialValue = props.value;
+
+  if (typeof initialValue === "undefined") {
+    const head = props.options[0] as TwinRadioGroup["options"][0];
+    initialValue = head.value;
+  }
+
+  const [value, setValue] = useState(initialValue);
+
+  useEffect(() => {
+    if (initialValue && initialValue !== value) {
+      setValue(initialValue);
+    }
+  }, [initialValue]);
+
+  return (
+    <RadioGroup
+      className="grid grid-cols-2 w-full font-semibold"
+      value={value}
+      onChange={(option: string) => {
+        if (props.onChange) {
+          props.onChange(option);
+        } else {
+          setValue(option);
+        }
+      }}
+      name={props.name}
+    >
+      {props.options.map((item, index) => {
+        const rounded =
+          index === 0 ? "rounded-tl rounded-bl" : "rounded-tr rounded-br";
+        return (
+          <RadioGroup.Option
+            key={item.value}
+            value={item.value}
+            className={({ checked, active }) =>
+              clsx(
+                "p-2 text-center text-sm cursor-pointer",
+                rounded,
+                checked
+                  ? "bg-gray-700 text-gray-200 z-10"
+                  : "bg-gray-800 text-gray-700",
+                active ? "ring-1 ring-indigo-500" : "",
+                "hover:ring-1 hover:ring-indigo-300 hover:z-20",
+              )
+            }
+          >
+            {item.title}
+          </RadioGroup.Option>
+        );
+      })}
+    </RadioGroup>
+  );
+};

--- a/packages/ui/src/components/TwinRadioGroup/TwinRadioGroup.tsx
+++ b/packages/ui/src/components/TwinRadioGroup/TwinRadioGroup.tsx
@@ -5,13 +5,11 @@ import { RadioGroup } from "@headlessui/react";
 import clsx from "clsx";
 
 export type TwinRadioGroup = {
-  options: {
-    title: string;
-    value: string;
-  }[];
-  value?: string;
-  onChange?: undefined | null | ((value: string) => void);
+  className?: string;
   name: string;
+  onChange?: undefined | null | ((value: string) => void);
+  options: { title: string; value: string }[];
+  value?: string;
 };
 
 export const TwinRadioGroup: FC<TwinRadioGroup> = (props) => {
@@ -32,7 +30,10 @@ export const TwinRadioGroup: FC<TwinRadioGroup> = (props) => {
 
   return (
     <RadioGroup
-      className="grid grid-cols-2 w-full font-semibold"
+      className={clsx(
+        "grid grid-cols-2 w-full font-semibold text-xs",
+        props.className,
+      )}
       value={value}
       onChange={(option: string) => {
         if (props.onChange) {
@@ -52,7 +53,7 @@ export const TwinRadioGroup: FC<TwinRadioGroup> = (props) => {
             value={item.value}
             className={({ checked, active }) =>
               clsx(
-                "p-2 text-center text-sm cursor-pointer",
+                "p-2 text-center cursor-pointer",
                 rounded,
                 checked
                   ? "bg-gray-700 text-gray-200 z-10"

--- a/packages/ui/src/components/TwinRadioGroup/index.ts
+++ b/packages/ui/src/components/TwinRadioGroup/index.ts
@@ -1,0 +1,1 @@
+export * from "./TwinRadioGroup";

--- a/packages/ui/src/components/index.ts
+++ b/packages/ui/src/components/index.ts
@@ -17,3 +17,4 @@ export * from "./TabsWithSuspense";
 export * from "./Toggle";
 export * from "./Tooltip";
 export * from "./transitions";
+export * from "./TwinRadioGroup";


### PR DESCRIPTION
### summary

- add flag `--no-open` to storybook, to avoid browser disruption
- create TwinRadioGroup component to match Figma design's
- uncontrolled + controlled versions, uncontrolled to be used in HTML Forms and controlled for specific cases

### screenshot
[components-TwinRadioGroup---Controlled-⋅-Storybook.webm](https://user-images.githubusercontent.com/829902/179145736-f059ccdd-081c-4ebb-9605-74166bfcc1da.webm)

