### PR TITLE
feat: Extend TokenSelector props to support Margin designs

### DIFF
--- a/apps/dex/src/pages/swap.tsx
+++ b/apps/dex/src/pages/swap.tsx
@@ -417,7 +417,6 @@ const SwapPage = () => {
                 </legend>
                 <div className="flex flex-col gap-2 md:flex-row md:justify-between md:items-end">
                   <TokenSelector
-                    label=""
                     modalTitle="From"
                     value={fromDenom}
                     onChange={(token) =>

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -11,7 +11,7 @@
     "tailwind.config.preset.js"
   ],
   "scripts": {
-    "storybook": "start-storybook -p 6006",
+    "storybook": "start-storybook -p 6006 --no-open",
     "build-storybook": "build-storybook",
     "codegen:component": "node ./scripts/codegen.mjs component --",
     "svgr": "svgr ./assets/icons"

--- a/packages/ui/src/compounds/TokenSelector/TokenSelector.stories.tsx
+++ b/packages/ui/src/compounds/TokenSelector/TokenSelector.stories.tsx
@@ -8,14 +8,74 @@ export default {
   component: TokenSelector,
 } as ComponentMeta<typeof TokenSelector>;
 
-const Template: ComponentStory<typeof TokenSelector> = (args) => {
+export const Default: ComponentStory<typeof TokenSelector> = (args) => {
   return <TokenSelector {...args} />;
 };
-
-export const Default = Template.bind({});
-
 Default.args = {
   label: "Token",
   modalTitle: "From",
   tokens: [...tokens],
+};
+
+export const FixedWidthParent: ComponentStory<typeof TokenSelector> = (
+  args,
+) => {
+  return (
+    <div>
+      <ol className="list-decimal pl-4 mb-4">
+        <li>TokenSelctor respects the parent width</li>
+        <li>Adds text ellipsis when overflow</li>
+        <li>Do not break text in new line</li>
+        <li>Label is optional</li>
+      </ol>
+      <div style={{ width: 128 }}>
+        <TokenSelector {...args} />
+      </div>
+    </div>
+  );
+};
+FixedWidthParent.args = {
+  modalTitle: "From",
+  tokens: [...tokens],
+};
+
+export const SizeAndButtonCustomization: ComponentStory<
+  typeof TokenSelector
+> = (args) => {
+  return (
+    <div>
+      <ol className="list-decimal pl-4 mb-4">
+        <li>You can add extra classes to style the button container</li>
+        <li>Change the size of icons and text via `size` property</li>
+      </ol>
+      <div style={{ width: 128 }}>
+        <TokenSelector {...args} />
+      </div>
+    </div>
+  );
+};
+SizeAndButtonCustomization.args = {
+  modalTitle: "From",
+  tokens: [...tokens],
+  size: "xs",
+  buttonClassName: "border-none rounded-none",
+};
+
+export const Readonly: ComponentStory<typeof TokenSelector> = (args) => {
+  return (
+    <div>
+      <ol className="list-decimal pl-4 mb-4">
+        <li>You use `readonly` option to disable interactivity</li>
+        <li>The icon will change to a lock, indicating you can't change it</li>
+      </ol>
+      <div style={{ width: 256 }}>
+        <TokenSelector {...args} />
+      </div>
+    </div>
+  );
+};
+Readonly.args = {
+  modalTitle: "From",
+  tokens: [...tokens],
+  readonly: true,
 };

--- a/packages/ui/src/compounds/TokenSelector/TokenSelector.tsx
+++ b/packages/ui/src/compounds/TokenSelector/TokenSelector.tsx
@@ -12,6 +12,7 @@ import {
   RacetrackSpinnerIcon,
   SearchInput,
   SortIcon,
+  LockIcon,
 } from "../../components";
 import { useSortedArray } from "../../hooks";
 import { TokenItem, TokenItemProps } from "./TokenItem";
@@ -21,10 +22,15 @@ const ListContainer = tw.ul`
   grid gap-2 max-h-64 overflow-y-scroll -mx-3 no-scrollbar
 `;
 
-const AssetIcon: FC<{ imageUrl: string; hasDarkIcon?: boolean }> = (props) => (
+const AssetIcon: FC<{
+  imageUrl: string;
+  hasDarkIcon?: boolean;
+  size: TokenSelectorProps["size"];
+}> = (props) => (
   <figure
     className={clsx(
-      "h-6 w-6 rounded-full grid place-items-center overflow-hidden bg-black ring-4 ring-black/60",
+      props.size === "xs" ? "h4- w-4" : "h-6 w-6",
+      "rounded-full grid place-items-center overflow-hidden bg-black ring-4 ring-black/60",
       {
         "!bg-white": props.hasDarkIcon,
       },
@@ -33,18 +39,23 @@ const AssetIcon: FC<{ imageUrl: string; hasDarkIcon?: boolean }> = (props) => (
     {props.imageUrl ? (
       <AsyncImage src={props.imageUrl} />
     ) : (
-      <RacetrackSpinnerIcon className="h-6 w-6" />
+      <RacetrackSpinnerIcon
+        className={clsx(props.size === "xs" ? "h4- w-4" : "h-6 w-6")}
+      />
     )}
   </figure>
 );
 
 export type TokenSelectorProps = {
-  label: string;
+  label?: string;
   modalTitle: string;
   tokens: TokenEntry[];
   renderTokenItem?: FC<TokenItemProps>;
   value?: TokenEntry | undefined;
   onChange?: (token: TokenEntry) => void;
+  size?: "xs";
+  buttonClassName?: string;
+  readonly?: boolean;
 };
 
 type SortKeys = keyof TokenEntry;
@@ -90,20 +101,25 @@ export const TokenSelector: FC<TokenSelectorProps> = (props) => {
 
   return (
     <>
-      <div>
-        <span className="input-label">{props.label}</span>
+      <div className={clsx("flex flex-col", props.size === "xs" && "text-xs")}>
+        {props.label && <span className="input-label">{props.label}</span>}
         <button
-          className="input flex flex-1 items-center gap-4"
+          className={clsx(
+            "input flex flex-1 items-center gap-4",
+            props.buttonClassName,
+          )}
           onClick={(e) => {
             e.preventDefault();
             setIsOpen(true);
           }}
+          disabled={props.readonly}
         >
           {selectedToken ? (
             <>
               <AssetIcon
                 imageUrl={selectedToken.imageUrl ?? ""}
                 hasDarkIcon={Boolean(selectedToken.hasDarkIcon)}
+                size={props.size}
               />
               <span className="uppercase text-white">
                 {selectedToken.displaySymbol}
@@ -111,11 +127,25 @@ export const TokenSelector: FC<TokenSelectorProps> = (props) => {
             </>
           ) : (
             <>
-              <AssetIcon imageUrl="" />
+              <AssetIcon imageUrl="" size={props.size} />
               <span className="uppercase text-white">...</span>
             </>
           )}
-          <ChevronDownIcon className="h-4 w-4 text-gray-400" />
+          {props.readonly ? (
+            <LockIcon
+              className={clsx(
+                "ml-auto",
+                props.size === "xs" ? "h-3 w-3" : "h-4 w-4",
+              )}
+            />
+          ) : (
+            <ChevronDownIcon
+              className={clsx(
+                "ml-auto text-gray-400",
+                props.size === "xs" ? "h-3 w-3" : "h-4 w-4",
+              )}
+            />
+          )}
         </button>
       </div>
       <Modal

--- a/packages/ui/src/compounds/TokenSelector/TokenSelector.tsx
+++ b/packages/ui/src/compounds/TokenSelector/TokenSelector.tsx
@@ -134,7 +134,7 @@ export const TokenSelector: FC<TokenSelectorProps> = (props) => {
           {props.readonly ? (
             <LockIcon
               className={clsx(
-                "ml-auto",
+                "ml-auto text-white",
                 props.size === "xs" ? "h-3 w-3" : "h-4 w-4",
               )}
             />

--- a/packages/ui/src/compounds/TokenSelector/TokenSelector.tsx
+++ b/packages/ui/src/compounds/TokenSelector/TokenSelector.tsx
@@ -121,7 +121,7 @@ export const TokenSelector: FC<TokenSelectorProps> = (props) => {
                 hasDarkIcon={Boolean(selectedToken.hasDarkIcon)}
                 size={props.size}
               />
-              <span className="uppercase text-white">
+              <span className="uppercase text-white overflow-hidden text-ellipsis whitespace-nowrap">
                 {selectedToken.displaySymbol}
               </span>
             </>


### PR DESCRIPTION
### summary

- cherry-picking changes in `TokenSelector` from https://github.com/Sifchain/sifchain-ui-next/pull/42
- add an option to change icon and text size with the new `size` property
- add a read-only option to remove interactivity and change the icon to lock
- when the parent element has a fixed / limit in width, TokenSelector text adds an ellipsis in the end and doesn't break to a new line
- add new stories in Storybook to cover all new options and layouts
- backward compatible with current Swap page usage

### CURRENT - Token Selector API

![curren-token-selector](https://user-images.githubusercontent.com/829902/179446920-ed83229a-23bd-4b99-9b80-4c8566f1d3e6.png)

### NEW - Token Selector API - Screenview
[compounds-TokenSelector---Readonly-⋅-Storybook.webm](https://user-images.githubusercontent.com/829902/179446208-b0f27dfd-c6fd-45ec-bef2-17ac7c5ae2ec.webm)

