### PR TITLE
feat: add "no results" text in token selector when filter does not matching anything

### DIFF
--- a/packages/ui/src/compounds/TokenSelector/TokenSelector.tsx
+++ b/packages/ui/src/compounds/TokenSelector/TokenSelector.tsx
@@ -192,27 +192,31 @@ export const TokenSelector: FC<TokenSelectorProps> = (props) => {
             </div>
 
             <Combobox.Options as={ListContainer} static>
-              {filtered.map((token) => {
-                const ItemComponent = props.renderTokenItem ?? TokenItem;
+              {filtered.length === 0 ? (
+                <p className="text-center p-4">No matching results.</p>
+              ) : (
+                filtered.map((token) => {
+                  const ItemComponent = props.renderTokenItem ?? TokenItem;
 
-                return (
-                  <Combobox.Option
-                    key={`${token.symbol}-${
-                      token.homeNetwork ?? token.network
-                    }`}
-                    value={token}
-                  >
-                    {({ selected, active }) => (
-                      <ItemComponent
-                        {...token}
-                        balance="0.00"
-                        selected={selected}
-                        active={active}
-                      />
-                    )}
-                  </Combobox.Option>
-                );
-              })}
+                  return (
+                    <Combobox.Option
+                      key={`${token.symbol}-${
+                        token.homeNetwork ?? token.network
+                      }`}
+                      value={token}
+                    >
+                      {({ selected, active }) => (
+                        <ItemComponent
+                          {...token}
+                          balance="0.00"
+                          selected={selected}
+                          active={active}
+                        />
+                      )}
+                    </Combobox.Option>
+                  );
+                })
+              )}
             </Combobox.Options>
           </div>
         </Combobox>


### PR DESCRIPTION
### summary

- when the list provided to Token Selector has length = 0 or the filter string doesn't match any items, show "No matching results" item

### before

![Screen Shot 2022-07-19 at 2 55 15 PM](https://user-images.githubusercontent.com/829902/179654729-a476a183-fa35-4c6a-9d76-f6e54d2841c6.png)


### after
![Screen Shot 2022-07-19 at 2 54 21 PM](https://user-images.githubusercontent.com/829902/179654757-b9330b8c-0ea5-4727-842c-34ff1df38a74.png)

