### PR TITLE
refactor: rename `ibcDenom` to `denom`

### DIFF
--- a/apps/dex/src/compounds/AssetIcon/AssetIcon.tsx
+++ b/apps/dex/src/compounds/AssetIcon/AssetIcon.tsx
@@ -25,16 +25,16 @@ const AssetIcon: FC<Props> = memo((props) => {
     isLoading: isLoadingAsset,
     indexedBySymbol,
     indexedByDisplaySymbol,
-    indexedByIBCDenom,
+    indexedByDenom,
   } = useTokenRegistryQuery();
 
   const asset = useMemo(
     () =>
-      indexedByIBCDenom[props.symbol] ||
+      indexedByDenom[props.symbol] ||
       indexedBySymbol[props.symbol.toLowerCase()] ||
       indexedBySymbol[props.symbol.slice(1).toLowerCase()] ||
       indexedByDisplaySymbol[props.symbol.toLowerCase()],
-    [indexedByDisplaySymbol, indexedByIBCDenom, indexedBySymbol, props.symbol],
+    [indexedByDisplaySymbol, indexedByDenom, indexedBySymbol, props.symbol],
   );
 
   if (!asset) {

--- a/apps/dex/src/compounds/ExportModal/ExportModal.tsx
+++ b/apps/dex/src/compounds/ExportModal/ExportModal.tsx
@@ -27,12 +27,12 @@ import { useTokenRegistryQuery } from "~/domains/tokenRegistry";
 const ExportModal = (props: ModalProps & { denom: string }) => {
   const exportTokensMutation = useExportTokensMutation();
 
-  const { indexedByIBCDenom } = useTokenRegistryQuery();
+  const { indexedByDenom } = useTokenRegistryQuery();
   const balances = useAllBalancesQuery();
   const balance = balances.indexedByDenom?.[props.denom];
 
-  const token = indexedByIBCDenom[props.denom];
-  const isEthToken = token?.ibcDenom?.startsWith("c");
+  const token = indexedByDenom[props.denom];
+  const isEthToken = token?.denom?.startsWith("c");
   const { data: env } = useDexEnvironment();
   const { accounts: sifAccounts } = useAccounts(env?.sifChainId ?? "", {
     enabled: env !== undefined,
@@ -88,11 +88,11 @@ const ExportModal = (props: ModalProps & { denom: string }) => {
         return "Transaction failed";
       case "idle":
       default:
-        return `Export ${indexedByIBCDenom[
+        return `Export ${indexedByDenom[
           props.denom
         ]?.displaySymbol.toUpperCase()} from Sifchain`;
     }
-  }, [exportTokensMutation.status, indexedByIBCDenom, props.denom]);
+  }, [exportTokensMutation.status, indexedByDenom, props.denom]);
 
   const buttonMessage = useMemo(() => {
     if (error !== undefined) {

--- a/apps/dex/src/compounds/ImportModal/ImportModal.tsx
+++ b/apps/dex/src/compounds/ImportModal/ImportModal.tsx
@@ -36,8 +36,8 @@ const ImportModal = (
 ) => {
   const importTokensMutation = useImportTokensMutation();
 
-  const { data: tokenRegistry, indexedByIBCDenom } = useTokenRegistryQuery();
-  const token = indexedByIBCDenom[props.denom];
+  const { data: tokenRegistry, indexedByDenom } = useTokenRegistryQuery();
+  const token = indexedByDenom[props.denom];
   const balances = useAllBalancesQuery();
   const balance = balances.indexedByDenom?.[props.denom];
 
@@ -72,7 +72,7 @@ const ImportModal = (
   const tokenOptions = useMemo(
     () =>
       tokenRegistry.map((x) => ({
-        id: x.ibcDenom ?? "",
+        id: x.denom ?? "",
         label: x.displaySymbol,
         body: x.displaySymbol,
       })),
@@ -127,11 +127,11 @@ const ImportModal = (
         return "Transaction failed";
       case "idle":
       default:
-        return `Import ${indexedByIBCDenom[
+        return `Import ${indexedByDenom[
           props.denom
         ]?.displaySymbol.toUpperCase()} from Sifchain`;
     }
-  }, [importTokensMutation.status, indexedByIBCDenom, props.denom]);
+  }, [importTokensMutation.status, indexedByDenom, props.denom]);
 
   const buttonMessage = useMemo(() => {
     if (error !== undefined) {

--- a/apps/dex/src/compounds/TokenSelector/TokenSelector.tsx
+++ b/apps/dex/src/compounds/TokenSelector/TokenSelector.tsx
@@ -14,7 +14,7 @@ export type TokenSelectorProps = Omit<
 > & { value?: string; onChange: (token?: EnhancedRegitryAsset) => unknown };
 
 const toTokenEntry = <T extends IAsset>(x: T) => ({
-  id: x.ibcDenom,
+  id: x.denom,
   name: x.name,
   symbol: x.symbol,
   displaySymbol: x.displaySymbol,
@@ -29,10 +29,10 @@ const toTokenEntry = <T extends IAsset>(x: T) => ({
 });
 
 const TokenSelector = (props: TokenSelectorProps) => {
-  const { data: registry, indexedByIBCDenom } = useTokenRegistryQuery();
+  const { data: registry, indexedByDenom } = useTokenRegistryQuery();
 
   const token =
-    props.value === undefined ? undefined : indexedByIBCDenom[props.value];
+    props.value === undefined ? undefined : indexedByDenom[props.value];
 
   return (
     <BaseTokenSelector
@@ -40,9 +40,8 @@ const TokenSelector = (props: TokenSelectorProps) => {
       value={token === undefined ? undefined : toTokenEntry(token)}
       tokens={useMemo(() => registry.map(toTokenEntry), [registry])}
       onChange={useCallback(
-        (token: TokenEntry) =>
-          props.onChange(indexedByIBCDenom[token.id ?? ""]),
-        [indexedByIBCDenom, props],
+        (token: TokenEntry) => props.onChange(indexedByDenom[token.id ?? ""]),
+        [indexedByDenom, props],
       )}
     />
   );

--- a/apps/dex/src/domains/bank/hooks/balances.ts
+++ b/apps/dex/src/domains/bank/hooks/balances.ts
@@ -26,8 +26,8 @@ export const useBalanceQuery = (
 ) => {
   const { client } = useStargateClient(chainId, options);
   const { accounts } = useAccounts(chainId, options);
-  const { indexedByIBCDenom } = useTokenRegistryQuery();
-  const token = indexedByIBCDenom[denom];
+  const { indexedByDenom } = useTokenRegistryQuery();
+  const token = indexedByDenom[denom];
 
   return useQuery(
     ["cosm-balance", chainId, denom],
@@ -62,7 +62,7 @@ export function useAllBalancesQuery() {
   const { data: stargateClient } = useSifStargateClient();
   const {
     data: registry,
-    indexedByIBCDenom,
+    indexedByDenom,
     isSuccess: isTokenRegistryQuerySuccess,
   } = useTokenRegistryQuery();
 
@@ -76,7 +76,7 @@ export function useAllBalancesQuery() {
 
       return (
         balances?.map((x) => {
-          const token = indexedByIBCDenom[x.denom];
+          const token = indexedByDenom[x.denom];
           return {
             ...x,
             amount:
@@ -106,11 +106,11 @@ export function useAllBalancesQuery() {
       baseQuery.data === undefined || registry === undefined
         ? {}
         : registry
-            .filter((x) => x.ibcDenom in indexedByDenom)
+            .filter((x) => x.denom in indexedByDenom)
             .reduce(
               (acc, x) => ({
                 ...acc,
-                [x.symbol.toLowerCase()]: indexedByDenom[x.ibcDenom] as Balance,
+                [x.symbol.toLowerCase()]: indexedByDenom[x.denom] as Balance,
               }),
               {} as StringIndexed<Balance>,
             );
@@ -119,12 +119,12 @@ export function useAllBalancesQuery() {
       baseQuery.data === undefined || registry === undefined
         ? {}
         : registry
-            .filter((x) => x.ibcDenom in indexedByDenom && x.displaySymbol)
+            .filter((x) => x.denom in indexedByDenom && x.displaySymbol)
             .reduce(
               (acc, x) => ({
                 ...acc,
                 [x.displaySymbol.toLowerCase()]: indexedByDenom[
-                  x.ibcDenom
+                  x.denom
                 ] as Balance,
               }),
               {} as StringIndexed<Balance>,
@@ -156,7 +156,7 @@ export function useAllBalancesQuery() {
 }
 
 export function useBalancesWithPool() {
-  const { indexedByIBCDenom } = useTokenRegistryQuery();
+  const { indexedByDenom } = useTokenRegistryQuery();
   const { data: liquidityProviders } = useLiquidityProviders();
   const { data: balances } = useAllBalancesQuery();
   const { data: env } = useDexEnvironment();
@@ -183,7 +183,7 @@ export function useBalancesWithPool() {
   return useMemo(
     () =>
       Array.from(denomSet).map((x) => {
-        const token = indexedByIBCDenom[x];
+        const token = indexedByDenom[x];
         const balance = balances?.find((y) => y.denom === x);
         const pool = liquidityProviders?.pools.find(
           (y) => y.liquidityProvider?.asset?.symbol === x,
@@ -205,7 +205,7 @@ export function useBalancesWithPool() {
       balances,
       denomSet,
       env?.nativeAsset.symbol,
-      indexedByIBCDenom,
+      indexedByDenom,
       liquidityProviders?.pools,
       totalRowan,
     ],
@@ -216,8 +216,8 @@ export function useBalancesStats() {
   const { data: stargateClient } = useSifStargateClient();
   const balances = useBalancesWithPool();
 
-  const { indexedByIBCDenom } = useTokenRegistryQuery();
-  const usdcToken = indexedByIBCDenom["cusdc"];
+  const { indexedByDenom } = useTokenRegistryQuery();
+  const usdcToken = indexedByDenom["cusdc"];
 
   return useQuery(
     ["balances-stats", balances],

--- a/apps/dex/src/domains/clp/hooks/liquidityProvider.ts
+++ b/apps/dex/src/domains/clp/hooks/liquidityProvider.ts
@@ -10,7 +10,7 @@ export const useLiquidityProviders = () => {
   const { signer } = useSigner(env?.sifChainId ?? "", {
     enabled: env !== undefined,
   });
-  const { isSuccess: isTokenRegistrySuccess, indexedByIBCDenom } =
+  const { isSuccess: isTokenRegistrySuccess, indexedByDenom } =
     useTokenRegistryQuery();
   const { data: sifQueryClient } = useQueryClient();
 
@@ -30,7 +30,7 @@ export const useLiquidityProviders = () => {
               ...x,
               externalAssetBalance: Decimal.fromAtomics(
                 x.externalAssetBalance,
-                indexedByIBCDenom[x.liquidityProvider?.asset?.symbol ?? ""]
+                indexedByDenom[x.liquidityProvider?.asset?.symbol ?? ""]
                   ?.decimals ?? 0,
               ),
               nativeAssetBalance: Decimal.fromAtomics(

--- a/apps/dex/src/domains/clp/hooks/usePools.ts
+++ b/apps/dex/src/domains/clp/hooks/usePools.ts
@@ -5,7 +5,7 @@ import { useTokenRegistryQuery } from "~/domains/tokenRegistry";
 import useSifnodeQuery from "~/hooks/useSifnodeQuery";
 
 export function usePoolsQuery() {
-  const { data: tokenRegistryRes, indexedByIBCDenom } = useTokenRegistryQuery();
+  const { data: tokenRegistryRes, indexedByDenom } = useTokenRegistryQuery();
   const { data: poolsRes } = useSifnodeQuery("clp.getPools", [{}]);
   const { data: env } = useDexEnvironment();
 
@@ -20,7 +20,7 @@ export function usePoolsQuery() {
               ...x,
               externalAssetBalance: Decimal.fromAtomics(
                 x.externalAssetBalance,
-                indexedByIBCDenom[x.externalAsset?.symbol ?? ""]?.decimals ?? 0,
+                indexedByDenom[x.externalAsset?.symbol ?? ""]?.decimals ?? 0,
               ),
               nativeAssetBalance: Decimal.fromAtomics(
                 x.nativeAssetBalance,

--- a/apps/dex/src/domains/clp/hooks/useSwapMutation.ts
+++ b/apps/dex/src/domains/clp/hooks/useSwapMutation.ts
@@ -10,7 +10,7 @@ import { useSifSigningStargateClient } from "~/hooks/useSifStargateClient";
 export const useSwapMutation = () => {
   const { signer } = useSifSigner();
   const { data: signingStargateClient } = useSifSigningStargateClient();
-  const { indexedByIBCDenom } = useTokenRegistryQuery();
+  const { indexedByDenom } = useTokenRegistryQuery();
 
   return useMutation(
     async (variables: {
@@ -45,8 +45,8 @@ export const useSwapMutation = () => {
         if (data === undefined || Boolean(error) || isDeliverTxFailure(data)) {
           toast.error(data?.rawLog ?? "Failed to swap");
         } else if (data !== undefined && isDeliverTxSuccess(data)) {
-          const fromCoin = indexedByIBCDenom[variables.fromDenom];
-          const toCoin = indexedByIBCDenom[variables.toDenom];
+          const fromCoin = indexedByDenom[variables.fromDenom];
+          const toCoin = indexedByDenom[variables.toDenom];
           const fromSymbol = fromCoin?.displaySymbol;
           const toSymbol = toCoin?.displaySymbol;
 

--- a/apps/dex/src/domains/tokenRegistry/hooks/useTokenRegistry.ts
+++ b/apps/dex/src/domains/tokenRegistry/hooks/useTokenRegistry.ts
@@ -11,7 +11,7 @@ import useSifnodeQuery from "~/hooks/useSifnodeQuery";
 
 export type EnhancedRegitryAsset = IAsset & {
   chainId: string;
-  ibcDenom: string;
+  denom: string;
 };
 
 export default function useTokenRegistryQuery(
@@ -52,7 +52,7 @@ export default function useTokenRegistryQuery(
             .find((x) => x.symbol === entry.denom.replace(/^c/, ""))?.address;
 
           asset.chainId = chainId;
-          asset.ibcDenom = entry.denom;
+          asset.denom = entry.denom;
           asset.address = address;
           acc.enhancedAssets.push(asset);
         }
@@ -76,7 +76,7 @@ export default function useTokenRegistryQuery(
       return {
         indexedBySymbol: {} as StringIndexed<EnhancedRegitryAsset>,
         indexedByDisplaySymbol: {} as StringIndexed<EnhancedRegitryAsset>,
-        indexedByIBCDenom: {} as StringIndexed<EnhancedRegitryAsset>,
+        indexedByDenom: {} as StringIndexed<EnhancedRegitryAsset>,
       };
     }
 
@@ -85,12 +85,12 @@ export default function useTokenRegistryQuery(
       compose(toLower, prop("displaySymbol")),
       entries,
     );
-    const indexedByIBCDenom = indexBy(prop("ibcDenom"), entries);
+    const indexedByDenom = indexBy(prop("denom"), entries);
 
     return {
       indexedBySymbol,
       indexedByDisplaySymbol,
-      indexedByIBCDenom,
+      indexedByDenom,
     };
   }, [entries, query.isSuccess]);
 
@@ -103,7 +103,7 @@ export default function useTokenRegistryQuery(
     findBySymbolOrDenom: memoizeWith(identity, (symbolOrDenom: string) => {
       const sanitized = symbolOrDenom.toLowerCase();
       return (
-        indices.indexedByIBCDenom[sanitized] ??
+        indices.indexedByDenom[sanitized] ??
         indices.indexedBySymbol[sanitized] ??
         indices.indexedByDisplaySymbol[sanitized]
       );

--- a/apps/dex/src/pages/swap.tsx
+++ b/apps/dex/src/pages/swap.tsx
@@ -161,14 +161,14 @@ function useEnhancedToken(
   const registryQuery = useTokenRegistryQuery();
   const allBalancesQuery = useAllBalancesQuery();
 
-  const registryEntry = registryQuery.indexedByIBCDenom[denom];
+  const registryEntry = registryQuery.indexedByDenom[denom];
   const balanceEntry = useMemo(
     () =>
       allBalancesQuery.data?.find(
         (entry) =>
-          entry.denom === denom || entry.denom === registryEntry?.ibcDenom,
+          entry.denom === denom || entry.denom === registryEntry?.denom,
       ),
-    [allBalancesQuery.data, registryEntry?.ibcDenom, denom],
+    [allBalancesQuery.data, registryEntry?.denom, denom],
   );
 
   const poolQuery = useSifnodeQuery(
@@ -288,13 +288,13 @@ const SwapPage = () => {
     return runCatching(() =>
       stargateClient?.simulateSwapSync(
         {
-          denom: fromToken?.ibcDenom ?? fromToken?.symbol ?? "",
+          denom: fromToken?.denom ?? fromToken?.symbol ?? "",
           amount: fromAmountDecimal?.atomics ?? "0",
           poolNativeAssetBalance: fromPool?.nativeAssetBalance ?? "0",
           poolExternalAssetBalance: fromPool?.externalAssetBalance ?? "0",
         },
         {
-          denom: toToken?.ibcDenom ?? toToken?.symbol ?? "",
+          denom: toToken?.denom ?? toToken?.symbol ?? "",
           poolNativeAssetBalance: toPool?.nativeAssetBalance ?? "0",
           poolExternalAssetBalance: toPool?.externalAssetBalance ?? "0",
         },
@@ -414,7 +414,7 @@ const SwapPage = () => {
                     modalTitle="From"
                     value={fromDenom}
                     onChange={(token) =>
-                      token && setDenomsPair(token.ibcDenom, undefined)
+                      token && setDenomsPair(token.denom, undefined)
                     }
                   />
                   <Input
@@ -464,7 +464,7 @@ const SwapPage = () => {
                     modalTitle="From"
                     value={toDenom}
                     onChange={(token) =>
-                      token && setDenomsPair(undefined, token.ibcDenom)
+                      token && setDenomsPair(undefined, token.denom)
                     }
                   />
                   <Input
@@ -541,8 +541,8 @@ const SwapPage = () => {
             switch (swapMutation.status) {
               case "idle":
                 swapMutation.mutate({
-                  fromDenom: fromToken?.ibcDenom ?? "",
-                  toDenom: toToken?.ibcDenom ?? "",
+                  fromDenom: fromToken?.denom ?? "",
+                  toDenom: toToken?.denom ?? "",
                   fromAmount: fromAmountDecimal?.atomics ?? "0",
                   minimumReceiving:
                     swapSimulationResult?.minimumReceiving ?? "0",

--- a/packages/common/src/entities/Asset.ts
+++ b/packages/common/src/entities/Asset.ts
@@ -8,7 +8,7 @@ export type IAsset = {
   network: NetworkKind;
   symbol: string;
   unitDenom?: string;
-  ibcDenom?: string;
+  denom?: string;
   displaySymbol: string;
   lowercasePrefixLength?: number;
   label?: string;


### PR DESCRIPTION
`ibcDenom` is not semantically correct since possible values can include for example:
- native denom: `rowan`
- peggy denom: `cusdc`, `sifBridge00010x0000000000000000000000000000000000000000`
- ibc denom: `ibc/330D65554F859FB20E13413C88951CFE774DD2D83F593417A0552C0607C92225`