### PR TITLE
fix: keplr wallet permission request

### DIFF
--- a/packages/cosmos-connect/src/core/connectors/injectedKeplr.ts
+++ b/packages/cosmos-connect/src/core/connectors/injectedKeplr.ts
@@ -71,15 +71,14 @@ export class InjectedKeplrConnector extends BaseCosmConnector<InjectedKeplrConne
       return currentPromise;
     }
 
-    const promise = this.#getSigner(chainId);
+    const promise = this.#getSigner(chainId).then((x) => {
+      delete this.#signerPromises[chainId];
+      return x;
+    });
 
     this.#signerPromises[chainId] = promise;
 
-    const result = await promise;
-
-    delete this.#signerPromises[chainId];
-
-    return result;
+    return promise;
   }
 
   async getStargateClient(chainId: string): Promise<StargateClient> {


### PR DESCRIPTION
work around for Keplr wallet bug where if multiple permission requests happened simultaneously
every subsequent requests return a denied error, even if the user click on accept