### PR TITLE
fix: react-query v4 requires checking two status keys

### DIFF
--- a/apps/dex/src/compounds/Margin/HistoryTable.tsx
+++ b/apps/dex/src/compounds/Margin/HistoryTable.tsx
@@ -59,7 +59,7 @@ export type HistoryTableProps = {
 const HistoryTable = (props: HistoryTableProps) => {
   const router = useRouter();
   const tokenRegistryQuery = useTokenRegistryQuery();
-  const walletAddress = useSifSignerAddressQuery();
+  const walletAddressQuery = useSifSignerAddressQuery();
 
   const headers = HISTORY_HEADER_ITEMS;
 
@@ -71,18 +71,18 @@ const HistoryTable = (props: HistoryTableProps) => {
   };
   const historyQuery = useMarginHistoryQuery({
     ...queryParams,
-    walletAddress: walletAddress.data ?? "",
+    walletAddress: walletAddressQuery.data ?? "",
   });
 
-  if (walletAddress.isPaused) {
+  if (walletAddressQuery.fetchStatus === "idle" && walletAddressQuery.isLoading) {
     return <FlashMessageConnectSifChainWallet size="full-page" />;
   }
 
-  if (walletAddress.isError) {
+  if (walletAddressQuery.fetchStatus === "idle" && walletAddressQuery.isError) {
     return <FlashMessageConnectSifChainWalletError size="full-page" />;
   }
 
-  if (walletAddress.isLoading) {
+  if (walletAddressQuery.isFetching && walletAddressQuery.isLoading) {
     return <FlashMessageConnectSifChainWalletLoading size="full-page" />;
   }
 
@@ -90,7 +90,7 @@ const HistoryTable = (props: HistoryTableProps) => {
     return <FlashMessageLoading size="full-page" />;
   }
 
-  if (historyQuery.isSuccess && tokenRegistryQuery.isSuccess) {
+  if (historyQuery.isSuccess && tokenRegistryQuery.isSuccess && walletAddressQuery.isSuccess) {
     const { findBySymbolOrDenom } = tokenRegistryQuery;
     const { results, pagination } = historyQuery.data;
     const pages = Math.ceil(Number(pagination.total) / Number(pagination.limit));

--- a/apps/dex/src/compounds/Margin/OpenPositionsTable.tsx
+++ b/apps/dex/src/compounds/Margin/OpenPositionsTable.tsx
@@ -95,7 +95,7 @@ export type OpenPositionsTableProps = {
 const OpenPositionsTable = (props: OpenPositionsTableProps) => {
   const router = useRouter();
   const tokenRegistryQuery = useTokenRegistryQuery();
-  const walletAddress = useSifSignerAddressQuery();
+  const walletAddressQuery = useSifSignerAddressQuery();
   const { openPositionsQuery } = props;
 
   const { hideColumns, classNamePaginationContainer } = props;
@@ -123,15 +123,15 @@ const OpenPositionsTable = (props: OpenPositionsTableProps) => {
     }
   }, [positionToClose.value]);
 
-  if (walletAddress.isPaused) {
+  if (walletAddressQuery.fetchStatus === "idle" && walletAddressQuery.isLoading) {
     return <FlashMessageConnectSifChainWallet size="full-page" />;
   }
 
-  if (walletAddress.isError) {
+  if (walletAddressQuery.fetchStatus === "idle" && walletAddressQuery.isError) {
     return <FlashMessageConnectSifChainWalletError size="full-page" />;
   }
 
-  if (walletAddress.isLoading) {
+  if (walletAddressQuery.isFetching && walletAddressQuery.isLoading) {
     return <FlashMessageConnectSifChainWalletLoading size="full-page" />;
   }
 
@@ -139,7 +139,7 @@ const OpenPositionsTable = (props: OpenPositionsTableProps) => {
     return <FlashMessageLoading size="full-page" />;
   }
 
-  if (openPositionsQuery.isSuccess && tokenRegistryQuery.isSuccess) {
+  if (openPositionsQuery.isSuccess && tokenRegistryQuery.isSuccess && walletAddressQuery.isSuccess) {
     const { findBySymbolOrDenom } = tokenRegistryQuery;
     const { results, pagination } = openPositionsQuery.data;
     const pages = Math.ceil(Number(pagination.total) / Number(pagination.limit));

--- a/apps/dex/src/compounds/Margin/TradeActions.tsx
+++ b/apps/dex/src/compounds/Margin/TradeActions.tsx
@@ -62,7 +62,7 @@ export function TradeActions({
    * Wallet address scenarios
    * This is linekd with WalletConnector / Keplr behaviour
    */
-  if (walletAddressQuery.isPaused) {
+  if (walletAddressQuery.fetchStatus === "idle" && walletAddressQuery.isLoading) {
     return (
       <Layout>
         <FlashMessageConnectSifChainWallet className="col-span-4" />
@@ -70,7 +70,7 @@ export function TradeActions({
     );
   }
 
-  if (walletAddressQuery.isError) {
+  if (walletAddressQuery.fetchStatus === "idle" && walletAddressQuery.isError) {
     console.log({
       walletAddressQueryError: walletAddressQuery.error,
     });
@@ -81,7 +81,7 @@ export function TradeActions({
     );
   }
 
-  if (walletAddressQuery.isLoading) {
+  if (walletAddressQuery.isFetching && walletAddressQuery.isLoading) {
     return (
       <Layout>
         <FlashMessageConnectSifChainWalletLoading className="col-span-4" />
@@ -112,7 +112,7 @@ export function TradeActions({
     );
   }
 
-  if (isWhitelistedAccountQuery.isSuccess && govParams.whitelistingEnabled === true) {
+  if (isWhitelistedAccountQuery.isSuccess) {
     if (isWhitelistedAccountQuery.data.isWhitelisted === false) {
       return (
         <Layout>


### PR DESCRIPTION
### summary
- react-query v4 introduces two keys to check the fetch state in Queries
- we need to listen to the fetch status and query status

More information in:
- https://tanstack.com/query/v4/docs/guides/queries#why-two-different-states
- https://tkdodo.eu/blog/offline-react-query