### PR TITLE
feat: using react-query v4 structuralSharing to keep optimistic UI when syncing to server

### DIFF
--- a/apps/dex/src/compounds/Margin/HistoryTable.tsx
+++ b/apps/dex/src/compounds/Margin/HistoryTable.tsx
@@ -1,4 +1,4 @@
-import type { HistoryQueryData } from "~/domains/margin/hooks";
+import type { MarginHistoryQueryData } from "~/domains/margin/hooks";
 
 import { useRouter } from "next/router";
 import clsx from "clsx";
@@ -151,7 +151,7 @@ const HistoryTable = (props: HistoryTableProps) => {
             <tbody className="bg-gray-850">
               {results.length <= 0 && <NoResultsRow colSpan={headers.length} />}
               {results.map((x) => {
-                const item = x as HistoryQueryData & { _optimistic: boolean };
+                const item = x as MarginHistoryQueryData & { _optimistic: boolean };
                 const realizedPL = Number(item.realized_pnl ?? "0");
                 const realizedPLSign = Math.sign(Number(item.realized_pnl));
 

--- a/apps/dex/src/compounds/Margin/ModalMTPClose.tsx
+++ b/apps/dex/src/compounds/Margin/ModalMTPClose.tsx
@@ -1,4 +1,4 @@
-import type { OpenPositionsQueryData } from "~/domains/margin/hooks";
+import type { MarginOpenPositionsQueryData } from "~/domains/margin/hooks";
 
 import clsx from "clsx";
 import { Decimal } from "@cosmjs/math";
@@ -24,7 +24,7 @@ import { formatNumberAsPercent } from "./_intl";
 import { HtmlUnicode, removeFirstCharsUC } from "./_trade";
 
 type ModalMTPCloseProps = {
-  data: OpenPositionsQueryData;
+  data: MarginOpenPositionsQueryData;
   isOpen: boolean;
   onClose: () => void;
   onMutationError?: (_error: Error) => void;

--- a/apps/dex/src/compounds/Margin/OpenPositionsTable.tsx
+++ b/apps/dex/src/compounds/Margin/OpenPositionsTable.tsx
@@ -1,5 +1,5 @@
 import type {
-  OpenPositionsQueryData,
+  MarginOpenPositionsQueryData,
   useMarginOpenPositionsBySymbolQuery,
   useOpenPositionsQuery,
 } from "~/domains/margin/hooks";
@@ -103,7 +103,7 @@ const OpenPositionsTable = (props: OpenPositionsTableProps) => {
 
   const [positionToClose, setPositionToClose] = useState<{
     isOpen: boolean;
-    value: OpenPositionsQueryData | null;
+    value: MarginOpenPositionsQueryData | null;
   }>({
     isOpen: false,
     value: null,
@@ -235,7 +235,7 @@ const OpenPositionsTable = (props: OpenPositionsTableProps) => {
             <tbody className="bg-gray-850">
               {results.length <= 0 && <NoResultsRow colSpan={headers.length} />}
               {results.map((x) => {
-                const item = x as OpenPositionsQueryData & { _optimistic: boolean };
+                const item = x as MarginOpenPositionsQueryData & { _optimistic: boolean };
 
                 let custodyAsset;
                 let collateralAsset;

--- a/apps/dex/src/domains/margin/hooks/types.ts
+++ b/apps/dex/src/domains/margin/hooks/types.ts
@@ -1,3 +1,13 @@
+export type MarginHistoryResponse = {
+  pagination: Pagination;
+  results: MarginHistoryQueryData[];
+};
+
+export type MarginOpenPositionsResponse = {
+  pagination: Pagination;
+  results: MarginOpenPositionsQueryData[];
+};
+
 export type Pagination = {
   total: string;
   limit: string;
@@ -6,7 +16,7 @@ export type Pagination = {
   sort_by: string;
 };
 
-export type OpenPositionsQueryData = {
+export type MarginOpenPositionsQueryData = {
   address: string;
   date_opened: string;
   pool: string;
@@ -48,7 +58,7 @@ export type TimeOpen = {
   seconds: number;
 };
 
-export interface HistoryQueryData {
+export interface MarginHistoryQueryData {
   address: string;
   id: string;
   pool: string;

--- a/apps/dex/src/domains/margin/hooks/useMarginHistoryQuery.ts
+++ b/apps/dex/src/domains/margin/hooks/useMarginHistoryQuery.ts
@@ -1,5 +1,5 @@
+import type { MarginHistoryResponse } from "./types";
 import type { UseQueryResult } from "@tanstack/react-query";
-import type { Pagination, HistoryQueryData } from "./types";
 
 import useSifApiQuery from "~/hooks/useSifApiQuery";
 
@@ -30,9 +30,17 @@ export function useMarginHistoryQuery(params: {
        */
       refetchInterval: 10 * 1000,
       retry: false,
+      structuralSharing(oldData: MarginHistoryResponse | undefined, newData: MarginHistoryResponse | undefined) {
+        if (oldData && newData) {
+          const newDataIds = newData.results.map((x) => x.id);
+          const oldDataDiff = oldData.results.filter((x) => !newDataIds.includes(x.id));
+          newData.results = oldDataDiff.concat(newData.results);
+          newData.pagination.total = String(newData.results.length);
+          newData.pagination.limit = String(Number(newData.pagination.limit) + oldDataDiff.length);
+          return newData;
+        }
+        return newData;
+      },
     },
-  ) as UseQueryResult<{
-    pagination: Pagination;
-    results: HistoryQueryData[];
-  }>;
+  ) as UseQueryResult<MarginHistoryResponse>;
 }

--- a/apps/dex/src/domains/margin/hooks/useMarginMTPCloseMutation.ts
+++ b/apps/dex/src/domains/margin/hooks/useMarginMTPCloseMutation.ts
@@ -7,7 +7,7 @@ import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useSifSignerAddressQuery } from "~/hooks/useSifSigner";
 import { useSifSigningStargateClient } from "~/hooks/useSifStargateClient";
 import * as errors from "./mutationErrorMessage";
-import type { HistoryQueryData, MTPCloseResponse, OpenPositionsQueryData, Pagination } from "./types";
+import type { MarginHistoryQueryData, MTPCloseResponse, MarginOpenPositionsQueryData, Pagination } from "./types";
 
 export type CloseMTPVariables = Omit<MarginTX.MsgClose, "signer">;
 
@@ -108,7 +108,8 @@ export function useMarginMTPCloseMutation({ _optimisticCustodyAmount }: UseMargi
               },
             },
             (state) => {
-              const draft = state as { pagination: Pagination; results: Partial<OpenPositionsQueryData>[] } | undefined;
+              type PartialResponse = { pagination: Pagination; results: Partial<MarginOpenPositionsQueryData>[] };
+              const draft = state as PartialResponse | undefined;
               if (draft) {
                 draft.pagination = {
                   ...draft.pagination,
@@ -143,7 +144,8 @@ export function useMarginMTPCloseMutation({ _optimisticCustodyAmount }: UseMargi
               },
             },
             (state) => {
-              const draft = state as { pagination: Pagination; results: Partial<HistoryQueryData>[] } | undefined;
+              type PartialResponse = { pagination: Pagination; results: Partial<MarginHistoryQueryData>[] };
+              const draft = state as PartialResponse | undefined;
               if (draft) {
                 draft.pagination = {
                   ...draft.pagination,

--- a/apps/dex/src/domains/margin/hooks/useMarginMTPOpenMutation.ts
+++ b/apps/dex/src/domains/margin/hooks/useMarginMTPOpenMutation.ts
@@ -9,7 +9,7 @@ import { useSifSignerAddressQuery } from "~/hooks/useSifSigner";
 import { useSifSigningStargateClient } from "~/hooks/useSifStargateClient";
 
 import * as errors from "./mutationErrorMessage";
-import type { MTPOpenResponse, OpenPositionsQueryData, Pagination } from "./types";
+import type { MTPOpenResponse, MarginOpenPositionsQueryData, Pagination } from "./types";
 
 export type OpenMTPVariables = Omit<MarginTX.MsgOpen, "signer">;
 
@@ -145,7 +145,8 @@ export function useMarginMTPOpenMutation({ _optimisticCustodyAmount }: UseMargin
               },
             },
             (state) => {
-              const draft = state as { pagination: Pagination; results: Partial<OpenPositionsQueryData>[] } | undefined;
+              type PartialResponse = { pagination: Pagination; results: Partial<MarginOpenPositionsQueryData>[] };
+              const draft = state as PartialResponse | undefined;
               if (draft) {
                 draft.pagination = {
                   ...draft.pagination,

--- a/apps/dex/src/domains/margin/hooks/useMarginOpenPositionsBySymbolQuery.ts
+++ b/apps/dex/src/domains/margin/hooks/useMarginOpenPositionsBySymbolQuery.ts
@@ -1,4 +1,4 @@
-import type { Pagination, OpenPositionsQueryData } from "./types";
+import type { MarginOpenPositionsResponse } from "./types";
 import type { UseQueryResult } from "@tanstack/react-query";
 
 import { useRouter } from "next/router";
@@ -46,9 +46,20 @@ export function useMarginOpenPositionsBySymbolQuery({ poolSymbol }: { poolSymbol
        */
       refetchInterval: 10 * 1000,
       retry: false,
+      structuralSharing(
+        oldData: MarginOpenPositionsResponse | undefined,
+        newData: MarginOpenPositionsResponse | undefined,
+      ) {
+        if (oldData && newData) {
+          const newDataIds = newData.results.map((x) => x.id);
+          const oldDataDiff = oldData.results.filter((x) => !newDataIds.includes(x.id));
+          newData.results = oldDataDiff.concat(newData.results);
+          newData.pagination.total = String(newData.results.length);
+          newData.pagination.limit = String(Number(newData.pagination.limit) + oldDataDiff.length);
+          return newData;
+        }
+        return newData;
+      },
     },
-  ) as UseQueryResult<{
-    pagination: Pagination;
-    results: OpenPositionsQueryData[];
-  }>;
+  ) as UseQueryResult<MarginOpenPositionsResponse>;
 }

--- a/apps/dex/src/domains/margin/hooks/useMarginOpenPositionsQuery.ts
+++ b/apps/dex/src/domains/margin/hooks/useMarginOpenPositionsQuery.ts
@@ -1,4 +1,4 @@
-import type { Pagination, OpenPositionsQueryData } from "./types";
+import type { MarginOpenPositionsResponse } from "./types";
 import type { UseQueryResult } from "@tanstack/react-query";
 
 import { useRouter } from "next/router";
@@ -39,9 +39,20 @@ export function useOpenPositionsQuery() {
        */
       refetchInterval: 10 * 1000,
       retry: false,
+      structuralSharing(
+        oldData: MarginOpenPositionsResponse | undefined,
+        newData: MarginOpenPositionsResponse | undefined,
+      ) {
+        if (oldData && newData) {
+          const newDataIds = newData.results.map((x) => x.id);
+          const oldDataDiff = oldData.results.filter((x) => !newDataIds.includes(x.id));
+          newData.results = oldDataDiff.concat(newData.results);
+          newData.pagination.total = String(newData.results.length);
+          newData.pagination.limit = String(Number(newData.pagination.limit) + oldDataDiff.length);
+          return newData;
+        }
+        return newData;
+      },
     },
-  ) as UseQueryResult<{
-    pagination: Pagination;
-    results: OpenPositionsQueryData[];
-  }>;
+  ) as UseQueryResult<MarginOpenPositionsResponse>;
 }


### PR DESCRIPTION
### summary
- in the new react-query v4, `structuralSharing` accepts a function with the following signature:

```js
structuralSharing: boolean | ((oldData: TData | undefined, newData: TData) => TData)
```

- in Margin, when you open a new trade position or close a trade position, we use optimistic updates to add a placeholder item in the UI:

![Screen Shot 2022-09-01 at 9 21 21 PM](https://user-images.githubusercontent.com/829902/187879881-79a22e7d-4c72-40c0-b353-d552b8c84400.png)

- the interval for syncing in Margin is 10s and when the server syncing happened, and the item wasn't part of the response from DS, it would be removed from the UI (since the optimistic update wasn't part of DS response)
- this behavior is undesired; we want *to keep* the optimistic item until DS's response includes it

### solution
- using `structuralSharing` we can hook in the lifecycle of the cache update of react-query and create a diff between the current cache and the response from DS and keep the optimistic item in cache until it is included in the DS reponse