### PR TITLE
feat: add friendly error message when borrowed amount is too low

### DIFF
--- a/apps/dex/src/domains/margin/hooks/mutationErrorMessage.ts
+++ b/apps/dex/src/domains/margin/hooks/mutationErrorMessage.ts
@@ -11,3 +11,5 @@ export const POOL_MAX_OPEN_POSITIONS_REACHED =
 export const POOL_TRADE_TEMPORARILY_DISABLED = "Margin trading is temporarily disabled for this pool.";
 
 export const MTP_NOT_FOUND = "Unable to close the trade position. Trade ID not found.";
+export const MTP_LOW_BORROWED_AMOUNT =
+  "Sorry, the borrowed amount is too small. Try opening a position with higher leverage.";

--- a/apps/dex/src/domains/margin/hooks/useMarginMTPOpenMutation.ts
+++ b/apps/dex/src/domains/margin/hooks/useMarginMTPOpenMutation.ts
@@ -67,6 +67,10 @@ export function useMarginMTPOpenMutation({ _optimisticCustodyAmount }: UseMargin
         throw new Error(errors.ACCOUNT_NOT_IN_SIFCHAIN);
       }
 
+      if (res.rawLog.includes("borrowed amount is too low")) {
+        throw new Error(errors.MTP_LOW_BORROWED_AMOUNT);
+      }
+
       throw new Error(errors.DEFAULT_ERROR_OPEN_POSITION);
     }
 


### PR DESCRIPTION
### summary
- add a friendly error when the borrowed amount is too low
- ticket: https://app.zenhub.com/workspaces/current-sprint---engineering-615a2e9fe2abd5001befc7f9/issues/sifchain/issues/2178