### PR TITLE
chore: do not invalidate queries right after MTP Open or CLose

### DIFF
--- a/apps/dex/src/domains/margin/hooks/useMarginMTPCloseMutation.ts
+++ b/apps/dex/src/domains/margin/hooks/useMarginMTPCloseMutation.ts
@@ -122,9 +122,6 @@ export function useMarginMTPCloseMutation({ _optimisticCustodyAmount }: UseMargi
               return [newHistoryPosition];
             },
           );
-
-          queryClient.invalidateQueries(["margin.getMarginOpenPositionBySymbol"]);
-          queryClient.invalidateQueries(["margin.getMarginOpenPosition"]);
         }
       }
     },

--- a/apps/dex/src/domains/margin/hooks/useMarginMTPOpenMutation.ts
+++ b/apps/dex/src/domains/margin/hooks/useMarginMTPOpenMutation.ts
@@ -144,8 +144,6 @@ export function useMarginMTPOpenMutation(props: UseMarginMTPOpenMutationProps) {
             },
           );
 
-          queryClient.invalidateQueries(["margin.getMarginOpenPositionBySymbol"]);
-          queryClient.invalidateQueries(["margin.getMarginOpenPosition"]);
           queryClient.invalidateQueries(["all-balances"]);
         }
       }


### PR DESCRIPTION
### summary
- removing query invalidation from Positions queries
- we display Optimistic items in the UI when you Open or Close
- if we invalidate the query right after open/close mutation, the UI needs to wait until the request is finished to display the optimistic item: 
    - `mutation -> refetching -> optimistic item -> 10s refresh window`
- that is not the expected behaviour, we want to display it right after the mutation is complete: 
    - `mutation -> optimistic item -> 10s refresh window`