### PR TITLE
chore: move icons to the right in positions and history tables

### DIFF
--- a/apps/dex/src/compounds/Margin/HistoryTable.tsx
+++ b/apps/dex/src/compounds/Margin/HistoryTable.tsx
@@ -265,12 +265,12 @@ const HistoryTable = (props: HistoryTableProps) => {
                     <td className="px-4 py-3">
                       {isTruthy(item.close_interest_paid_custody) ? (
                         <div className="flex flex-row items-center justify-end tabular-nums">
-                          <AssetIcon symbol={item.open_custody_asset} network="sifchain" size="sm" />
-                          <span className="ml-1">
+                          <span className="mr-1">
                             {formatNumberAsDecimal(Number(item.close_interest_paid_custody), 6) ?? (
                               <HtmlUnicode name="EmDash" />
                             )}
                           </span>
+                          <AssetIcon symbol={item.open_custody_asset} network="sifchain" size="sm" />
                         </div>
                       ) : (
                         <HtmlUnicode name="EmDash" />
@@ -284,8 +284,8 @@ const HistoryTable = (props: HistoryTableProps) => {
                             "text-red-400": realizedPLSign === -1 && realizedPL < 0,
                           })}
                         >
+                          <span className="mr-1">{formatNumberAsDecimal(realizedPL, 6)}</span>
                           <AssetIcon symbol={item.open_collateral_asset} network="sifchain" size="sm" />
-                          <span className="ml-1">{formatNumberAsDecimal(realizedPL, 6)}</span>
                         </div>
                       ) : (
                         <HtmlUnicode name="EmDash" />

--- a/apps/dex/src/compounds/Margin/OpenPositionsTable.tsx
+++ b/apps/dex/src/compounds/Margin/OpenPositionsTable.tsx
@@ -352,10 +352,10 @@ const OpenPositionsTable = (props: OpenPositionsTableProps) => {
                             "text-red-400": unrealizedPLSign === -1 && unrealizedPnl < 0,
                           })}
                         >
-                          <AssetIcon symbol={item.collateral_asset} network="sifchain" size="sm" />
-                          <span className="ml-1">
+                          <span className="mr-1">
                             {formatNumberAsDecimal(unrealizedPnl, 6) ?? <HtmlUnicode name="EmDash" />}
                           </span>
+                          <AssetIcon symbol={item.collateral_asset} network="sifchain" size="sm" />
                         </div>
                       ) : (
                         <HtmlUnicode name="EmDash" />
@@ -374,10 +374,10 @@ const OpenPositionsTable = (props: OpenPositionsTableProps) => {
                       <td className="px-4 py-3">
                         {isTruthy(currentInterestPaidCustody) ? (
                           <div className="flex flex-row items-center justify-end tabular-nums">
-                            <AssetIcon symbol={item.custody_asset} network="sifchain" size="sm" />
-                            <span className="ml-1">
+                            <span className="mr-1">
                               {formatNumberAsDecimal(currentInterestPaidCustody, 6) ?? <HtmlUnicode name="EmDash" />}
                             </span>
+                            <AssetIcon symbol={item.custody_asset} network="sifchain" size="sm" />
                           </div>
                         ) : (
                           <HtmlUnicode name="EmDash" />


### PR DESCRIPTION
### summary
- move icons in positions and history tables to the right side of the value

### screenshots
![Screen Shot 2022-09-13 at 4 31 21 PM](https://user-images.githubusercontent.com/829902/189811216-06b2a373-7d1d-4219-bdaa-f85c11fc95be.png)
![Screen Shot 2022-09-13 at 4 31 12 PM](https://user-images.githubusercontent.com/829902/189811223-26212aab-4685-4f17-90bd-f3e29d7eac4d.png)
![Screen Shot 2022-09-13 at 4 30 54 PM](https://user-images.githubusercontent.com/829902/189811227-a0747f31-b2e8-4b11-b823-42270f3bb256.png)

