### PR TITLE
chore: using plain HTTP+IP instead of the CloudFlare domain name (HTT…

### DIFF
--- a/apps/dex/src/domains/core/envs/env.devnet.ts
+++ b/apps/dex/src/domains/core/envs/env.devnet.ts
@@ -3,6 +3,6 @@ import type { DexEnvironment } from ".";
 export default <DexEnvironment>{
   kind: "devnet",
   sifnodeUrl: "https://rpc-devnet.sifchain.finance",
-  vanirUrl: "https://data.sifchain.finance/beta",
+  vanirUrl: "http://65.109.54.24:8080/beta",
   registryUrl: "https://registry.sifchain.network",
 };

--- a/apps/dex/src/domains/core/envs/env.localnet.ts
+++ b/apps/dex/src/domains/core/envs/env.localnet.ts
@@ -3,6 +3,6 @@ import type { DexEnvironment } from ".";
 export default <DexEnvironment>{
   kind: "localnet",
   sifnodeUrl: "https://proxies.sifchain.finance/api/sifchain-testnet/rpc",
-  vanirUrl: "https://data.sifchain.finance/beta",
+  vanirUrl: "http://65.109.54.24:8080/beta",
   registryUrl: "https://registry.sifchain.network",
 };

--- a/apps/dex/src/domains/core/envs/env.testnet.ts
+++ b/apps/dex/src/domains/core/envs/env.testnet.ts
@@ -3,5 +3,5 @@ import type { DexEnvironment } from ".";
 export default <DexEnvironment>{
   kind: "testnet",
   sifnodeUrl: "https://proxies.sifchain.finance/api/sifchain-testnet/rpc",
-  vanirUrl: "https://data.sifchain.finance/beta",
+  vanirUrl: "http://65.109.54.24:8080/beta",
 };

--- a/packages/common/src/config/networks/config.devnet.json
+++ b/packages/common/src/config/networks/config.devnet.json
@@ -7,7 +7,7 @@
   "web3Provider--option2": "https://ropsten.infura.io/v3/f2e434009a9c4db8bfbd1b03ef572170",
   "nativeAsset": "rowan",
   "blockExplorerUrl": "https://blockexplorer-devnet.sifchain.finance",
-  "vanirUrl": "https://data.sifchain.finance/beta",
+  "vanirUrl": "http://65.109.54.24:8080/beta",
   "registryUrl": "https://registry.sifchain.network",
   "bridgebankContractAddress": "0x96DC6f02C66Bbf2dfbA934b8DafE7B2c08715A73",
   "keplrChainConfig": {

--- a/packages/common/src/config/networks/config.localnet.json
+++ b/packages/common/src/config/networks/config.localnet.json
@@ -5,7 +5,7 @@
   "sifRpcUrl": "http://localhost:3000/api/sifchain-local/rpc",
   "web3Provider": "metamask",
   "nativeAsset": "rowan",
-  "vanirUrl": "https://data.sifchain.finance/beta",
+  "vanirUrl": "http://65.109.54.24:8080/beta",
   "registryUrl": "https://registry.sifchain.network",
   "blockExplorerUrl": "https://blockexplorer.sifchain.finance",
   "bridgebankContractAddress": "0x30753E4A8aad7F8597332E813735Def5dD395028",

--- a/packages/common/src/config/networks/config.tempnet.json
+++ b/packages/common/src/config/networks/config.tempnet.json
@@ -7,7 +7,7 @@
   "nativeAsset": "rowan",
   "blockExplorerUrl": "https://blockexplorer-devnet.sifchain.finance",
   "bridgebankContractAddress": "0x96DC6f02C66Bbf2dfbA934b8DafE7B2c08715A73",
-  "vanirUrl": "https://data.sifchain.finance/beta",
+  "vanirUrl": "http://65.109.54.24:8080/beta",
   "registryUrl": "https://registry.sifchain.network",
   "keplrChainConfig": {
     "chainName": "Sifchain Tempnet (margin)",

--- a/packages/common/src/config/networks/config.testnet.json
+++ b/packages/common/src/config/networks/config.testnet.json
@@ -6,7 +6,7 @@
   "web3Provider": "metamask",
   "nativeAsset": "rowan",
   "blockExplorerUrl": "https://blockexplorer-testnet.sifchain.finance",
-  "vanirUrl": "https://data.sifchain.finance/beta",
+  "vanirUrl": "http://65.109.54.24:8080/beta",
   "registryUrl": "https://registry.sifchain.network",
   "bridgebankContractAddress": "0x6CfD69783E3fFb44CBaaFF7F509a4fcF0d8e2835",
   "keplrChainConfig": {

--- a/packages/sif-api/api.yaml
+++ b/packages/sif-api/api.yaml
@@ -4,7 +4,7 @@ info:
   version: 0.0.5
 servers:
   # Added by API Auto Mocking Plugin
-  - url: https://data.sifchain.finance/beta
+  - url: http://65.109.54.24:8080/beta
     description: AWS API Gateway
 
 tags:

--- a/packages/sif-api/src/generated/typescriptFetch/api.ts
+++ b/packages/sif-api/src/generated/typescriptFetch/api.ts
@@ -16,7 +16,7 @@ import * as url from "url";
 import * as isomorphicFetch from "isomorphic-fetch";
 import { Configuration } from "./configuration";
 
-const BASE_PATH = "https://data.sifchain.finance/beta".replace(/\/+$/, "");
+const BASE_PATH = "http://65.109.54.24:8080/beta".replace(/\/+$/, "");
 
 /**
  *


### PR DESCRIPTION
…PS), because the server is HTTP, and we dont have TLS termination anywhere in between (#227)