### PR TITLE
fix: handle  zero position result from a small collateral input

### DIFF
--- a/apps/dex/src/compounds/Margin/Trade.tsx
+++ b/apps/dex/src/compounds/Margin/Trade.tsx
@@ -398,7 +398,7 @@ const Trade = (props: TradeProps) => {
 
           setInputCollateral({
             value: payload.value,
-            error: "Collateral amount is too small",
+            error: "Collateral amount is still too small. Please enter a larger number.",
           });
         } else {
           setInputCollateral(payload);


### PR DESCRIPTION
I ran several tests on that scenario, it looks like an error when the decimal precision on the collateral input is higher than the number of decimals on the input asset, that means the resulting position cannot be approximated to a precise decimal

I've made a pull request to at least show an error on the collateral field stating it's too small

this is very edge-casey and I don't see it happening when users are opening real margin positions

for example, a resulting position, on whatever asset, would have to be smaller than 0.0001 of the target position asset to get this error

to put it in context, a resulting position of 0.0001 ETH is worth ~0.13 USD, I don't think anybody would ever:
1 - open a position so small position against ETH (or any high value asset)
2 - open a position with value under 1 USD